### PR TITLE
Always use the latest request-ssl

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/appcelerator/appc-platform-sdk",
   "dependencies": {
-    "appc-request-ssl": "^1.0.1",
+    "appc-request-ssl": "*",
     "async": "^0.9.0",
     "debug": "^2.1.0",
     "getmac": "^1.0.6",


### PR DESCRIPTION
Not using the latest ssl can cause issues when the fingerprints are updated.
This should fix that issue.