### PR TITLE
Minor changes to return proper error for JSON formatting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ function createAPIResponseHandler(callback, mapper) {
 			if (!body.success) {
 				debug('api body failed, was: %o', body);
 				var description = typeof(body.description) === 'object' ? body.description.message : body.description || 'unexpected response from the server';
-				var error = new Error();
+				var error = new Error(description);
 				error.success = false;
 				error.description = description;
 				error.code = body.code;

--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,9 @@ function createAPIResponseHandler(callback, mapper) {
 			if (!body.success) {
 				debug('api body failed, was: %o', body);
 				var description = typeof(body.description) === 'object' ? body.description.message : body.description || 'unexpected response from the server';
-				var error = new Error(description);
+				var error = new Error();
+				error.success = false;
+				error.description = description;
 				error.code = body.code;
 				error.internalCode = body.internalCode;
 				typeof(body) === 'string' && (error.content = body);


### PR DESCRIPTION
Once the Appc platform server returns any error while serving a request, I'm trying to format the error object with more fields so that it is easily consumable by any client (such as Studio).