### PR TITLE
[CLI-505/CLI-527] Rename App.update() to App.updateTiApp(), bump version

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -97,7 +97,7 @@ App.crittercismID = function crittercismID(session, guid, callback) {
 	AppC.createRequest(session, '/api/v1/app/' + guid + '/crittercism_id', callback);
 };
 
-App.update = function (session, orgId, tiappxml, callback) {
+App.updateTiApp = function (session, orgId, tiappxml, callback) {
 	var req = AppC.createRequest(session, '/api/v1/app/saveFromTiApp?org_id=' + orgId, 'post', callback);
 	if (req) {
 		var form = req.form();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Rename _App.update()_ to more appropriate name _App.updateTiApp()_
- Bump package version so the changes are published, this is what's causing [CLI-527](https://jira.appcelerator.org/browse/CLI-527)

NOTE : This depends on [appc-cli-titanium/pull/54](https://github.com/appcelerator/appc-cli-titanium/pull/54)

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-505)