### PR TITLE
[CLI-452] Set soastaUrl

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -55,6 +55,7 @@ Session.prototype._set = function (body) {
 		guid: body.guid,
 		org_id: body.org_id
 	};
+	this.soastaUrl = body['concerto'] || 'http://appctest-2.appcelerator.com/concerto';
 	return this;
 };
 


### PR DESCRIPTION
- Saves the soastaUrl

NOTE : This depends on
- [appc-registry-server/pull/23](https://github.com/appcelerator/appc-registry-server/pull/23)

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-452)