### PR TITLE
[REG-43] add better support for local env

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -151,7 +151,7 @@ function setCookieForDomain(session, name, value, domain, callback) {
 	var cookie = new tough.Cookie();
 	cookie.key = name;
 	cookie.value = value;
-	cookie.secure = true;
+	cookie.secure = AppC.secureCookies;
 	cookie.httpOnly = true;
 	cookie.path = '/';
 	cookie.domain = domain;

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,14 +84,16 @@ var DEFAULTS = {
 		registryurl: 'https://software.appcelerator.com',
 		securityurl: 'https://security.appcelerator.com',
 		isProduction: true,
-		supportUntrusted: false
+		supportUntrusted: false,
+		secureCookies: true
 	},
-	DEVELOPMENT: {
+	PREPRODUCTION: {
 		baseurl: 'https://360-preprod.cloud.appctest.com',
 		registryurl: 'https://8d2938f67044d8367d468453b5a6c2536185bcea.cloudapp-enterprise-preprod.appctest.com',
 		securityurl: 'https://de7a3ab4b12bf1d3d4b7fde7f306c11bc2b98f67.cloudapp-enterprise-preprod.appctest.com',
 		isProduction: false,
-		supportUntrusted: true
+		supportUntrusted: true,
+		secureCookies: true
 	}
 };
 
@@ -104,28 +106,31 @@ AppC.setProduction = function setProduction() {
 	AppC.securityurl = DEFAULTS.PRODUCTION.securityurl;
 	AppC.isProduction = DEFAULTS.PRODUCTION.isProduction;
 	AppC.supportUntrusted = DEFAULTS.PRODUCTION.supportUntrusted;
+	AppC.secureCookies = DEFAULTS.PRODUCTION.secureCookies;
 	debug('set production to ' + AppC.baseurl);
 };
 
 /**
  * set the base url to use development
  */
-AppC.setDevelopment = function setDevelopment() {
-	AppC.baseurl = DEFAULTS.DEVELOPMENT.baseurl;
-	AppC.registryurl = DEFAULTS.DEVELOPMENT.registryurl;
-	AppC.securityurl = DEFAULTS.DEVELOPMENT.securityurl;
-	AppC.isProduction = DEFAULTS.DEVELOPMENT.isProduction;
-	AppC.supportUntrusted = DEFAULTS.DEVELOPMENT.supportUntrusted;
-	debug('set dev to ' + AppC.baseurl);
+AppC.setPreproduction = function setPreproduction() {
+	AppC.baseurl = DEFAULTS.PREPRODUCTION.baseurl;
+	AppC.registryurl = DEFAULTS.PREPRODUCTION.registryurl;
+	AppC.securityurl = DEFAULTS.PREPRODUCTION.securityurl;
+	AppC.isProduction = DEFAULTS.PREPRODUCTION.isProduction;
+	AppC.supportUntrusted = DEFAULTS.PREPRODUCTION.supportUntrusted;
+	AppC.secureCookies = DEFAULTS.PREPRODUCTION.secureCookies;
+	debug('set preproduction to ' + AppC.baseurl);
 };
-AppC.setPreproduction = AppC.setDevelopment;
+AppC.setDevelopment = AppC.setPreproduction;
 
 /**
  * set the base url to use local development
  */
 AppC.setLocal = function setLocal() {
-	AppC.setDevelopment();
-	AppC.baseurl = 'https://360-local.appcelerator.com:8443';
+	AppC.setPreproduction();
+	AppC.baseurl = 'http://360-local.appcelerator.com:8443';
+	AppC.secureCookies = false;
 	AppC.isProduction = false;
 	debug('set local to ' + AppC.baseurl);
 };
@@ -135,12 +140,13 @@ AppC.setLocal = function setLocal() {
  */
 AppC.setEnvironment = function setEnvironment(opts) {
 	opts = opts || {};
-	var base = DEFAULTS[isRunningInPreproduction() ? 'DEVELOPMENT' : 'PRODUCTION'];
+	var base = DEFAULTS[isRunningInPreproduction() ? 'PREPRODUCTION' : 'PRODUCTION'];
 	AppC.baseurl = opts.baseurl || base.baseurl;
 	AppC.registryurl = opts.registry || base.registryurl;
 	AppC.securityurl = opts.security || base.securityurl;
 	AppC.isProduction = typeof opts.isProduction !== 'undefined' ? opts.isProduction : base.isProduction;
 	AppC.supportUntrusted = typeof opts.supportUntrusted !== 'undefined' ? opts.supportUntrusted : base.supportUntrusted;
+	AppC.secureCookies = typeof opts.secureCookies !== 'undefined' ? opts.secureCookies : base.secureCookies;
 	debug('set custom environment ' + JSON.stringify(opts) + ' to ' + AppC.baseurl);
 };
 
@@ -158,6 +164,7 @@ function isRunningInPreproduction() {
 }
 
 // if running in pre-production, assume by default we want preproduction setup
+// if actually running locally, the logic assumes production though
 if (isRunningInPreproduction()) {
 	AppC.setPreproduction();
 } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/REG-43
This PR adds functionality to allow the user to make requests to a local dashboard which doesn't have SSL certificates by passing in AppC.secureCookies  as an option for custom environments.
There are also a number of things that have been renamed from development to preproduction (keeping backwards compatibility) to lessen confusion due to development meaning the same as local in other modules.