### PR TITLE
[CLI-671] Add support for setting an IP as a baseurl in appc-platform-sdk

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -193,9 +193,10 @@ Auth.createSessionFromID = function createSessionFromID(id, callback) {
 	var url = require('url'),
 		async = require('async'),
 		parse = url.parse(AppC.baseurl),
-		host = parse.host,
+		isIP = /^\d{1,3}(?:\.\d{1,3}){3}/.test(parse.hostname),
+		host = isIP ? parse.hostname : parse.host,
 		tok = host.split('.'),
-		subdomain = tok.splice(tok.length - 2, 2).join('.'),
+		subdomain = isIP ? null : tok.splice(tok.length - 2, 2).join('.'),
 		session = new Session(host, subdomain);
 
 	session.id = id;


### PR DESCRIPTION
- This feature would enable us to mock the Appcelerator platform in unit-tests

[Jira Ticket](https://jira.appcelerator.org/browse/CLI-671)