### PR TITLE
Considering the touchtest URL

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -56,6 +56,7 @@ Session.prototype._set = function (body) {
 		org_id: body.org_id
 	};
 	this.soastaUrl = body.concerto || 'http://appctest-2.appcelerator.com/concerto';
+	this.touchtest = body.touchtest || 'http://appctest-2.appcelerator.com/concerto/touchtest';
 	return this;
 };
 


### PR DESCRIPTION
Making sure the session object in appc-platform-sdk also considers the touchtest URL after it receives the payload from registry server.