### PR TITLE
Fetch user/org from findSession, add packageId prop to session.org

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -216,7 +216,7 @@ Auth.createSessionFromID = function createSessionFromID(id, callback) {
 	], function (err) {
 		if (err) { return callback(err); }
 		// fetch the current user and org docs and set it on the session
-		AppC.createRequest(session, '/api/v1/auth/findSession', 'post', function (err, body, res) {
+		AppC.createRequest(session, '/api/v1/auth/findSession', 'get', function (err, body, res) {
 			if (err) {
 				return callback(err);
 			}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -54,7 +54,9 @@ function resolveUserOrg(session, next) {
 	// find our orgs
 	// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 	AppC.Org.find(session, function (err, orgs) {
-		if (err) { return next(err); }
+		if (err) {
+			return next(err);
+		}
 		session.orgs = {};
 		// map in our orgs
 		orgs && orgs.forEach(function (org) {
@@ -213,13 +215,22 @@ Auth.createSessionFromID = function createSessionFromID(id, callback) {
 		}
 	], function (err) {
 		if (err) { return callback(err); }
-		// fetch the current user and set it on the session
-		AppC.User.find(session, function (err, user) {
-			if (err && err.code === 403) {
+		// fetch the current user and org docs and set it on the session
+		AppC.createRequest(session, '/api/v1/auth/findSession', 'post', function (err, body, res) {
+			if (err) {
+				return callback(err);
+			}
+			if (!body || !body.user || !body.org) {
 				return callback(makeError('invalid session', Auth.ERROR_NOT_AUTHORIZED));
 			}
-			if (err) { return callback(err); }
-			session.user = user;
+			session.user = body.user;
+			session.org = {
+				name: body.org.name,
+				guid: body.org.guid,
+				org_id: body.org.org_id,
+				package: body.org.package,
+				packageId: body.org.packageId
+			};
 			resolveUserOrg(session, function (err) {
 				cachedSession = session;
 				cachedSessionKey = id;

--- a/test/appc_platform_sdk_tests.js
+++ b/test/appc_platform_sdk_tests.js
@@ -216,6 +216,8 @@ describe('appc-platform-AppC', function () {
 						should.exist(session.user.guid);
 						should.exist(session.user.org_id);
 						should.exist(session.user.org);
+						should.exist(session.org);
+						should.exist(session.org.packageId);
 						should.exist(session.orgs);
 						done();
 					});


### PR DESCRIPTION
This PR exposes org properties that are not part of the org doc in session.user.org (namely the org's packageId) in the session so it can be appended to PEM calls as needed (for query builder).

## Verification

1. `npm test`
