### PR TITLE
bump version for tough-cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^2.1.0",
     "getmac": "^1.0.6",
     "request": "^2.61.0",
-    "tough-cookie": "^0.12.1"
+    "tough-cookie": "^2.0.0"
   },
   "devDependencies": {
     "appc-registry-sdk": "*",


### PR DESCRIPTION
Bump version due to bug-fixes related to the error "Cookie has domain set to a public suffix" when using "127.0.0.1" or "localhost" as a cookie domain for testing.

This is required to support unit-tests in https://github.com/muhammaddadu/appc-security-server/tree/arrow-port