### PR TITLE
[SEC-29] When debugging appc-security-server, "appc:sdk form parameters for undefined" appears in the log

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -104,7 +104,7 @@ App.updateTiApp = function (session, orgId, tiappxml, callback) {
 	if (req) {
 		var form = req.form();
 		form.append('tiapp', tiappxml, {filename: 'tiapp.xml'});
-		debug('form parameters for %s, %o', req.url, form);
+		debug('form parameters for %s, %o', req.uri.href, form);
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To validate:
1. Clone appc-security-server 
2. Apply fix
3. Run appc-security-server with `DEBUG=* appc run -l trace`
4. Next, when creating a mobile project with appc cli, point your cli to your local running security server: `appc new --server http://127.0.0.1:8080/arrow -l trace`
5. In the appc-security-server console log, look for `appc:sdk form parameters`

Log should be `appc:sdk form parameters for <360_URL>, FormData {<AND_STUFF>}`