### PR TITLE
2.1.0 - [APPTS-9277] Inherit Env props from process.env vars

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -93,7 +93,8 @@ Env.setLocal = function setLocal(opts) {
  */
 Env.setEnvironment = function setEnvironment(opts) {
 	opts = opts || {};
-	let base = envs[_isPreproduction() ? 'Preproduction' : 'Production'];
+	let baseEnvKey = _getEnvKey();
+	let base = envs[baseEnvKey] || envs.Production;
 	Env.baseurl = (opts.baseurl || base.baseurl).trim();
 	Env.registryurl = (opts.registry || base.registryurl).trim();
 	Env.pubsuburl = (opts.pubsub || base.pubsuburl).trim();
@@ -126,33 +127,47 @@ function _isEnv(envs) {
 		|| ~envs.indexOf(process.env.APPC_ENV);
 }
 
-function _inheritEnvironment() {
-	Object.keys(platformMap).forEach(function (prop) {
-		var name = platformMap[prop];
-		var val = process.env[name];
+/**
+ * Test NODE_ENV and APPC_ENV values to see if they match env name(s).
+ * @return {String} - envs key name
+ */
+function _getEnvKey() {
+	if (_isPreproduction()) {
+		return 'Preproduction';
+	}
+	if (_isEnv('production-eu')) {
+		return 'ProductionEU';
+	}
+	if (_isEnv('platform-axway')) {
+		return 'PlatformAxway';
+	}
+	return 'Production';
+}
 
-		if (val) {
-			val = val.toLowerCase();
-			if (val === 'true') {
-				val = true;
-			} else if (val === 'false') {
-				val = false;
-			}
-			if (Env[prop] !== val) {
-				Env[prop] = val;
-			}
+/**
+ * Check process.env vars for override values.
+ * @return {void}
+ */
+function _inheritEnvVars() {
+	Object.keys(platformMap).forEach(function (prop) {
+		let name = platformMap[prop];
+		let val = process.env[name];
+
+		if (typeof val !== 'undefined') {
+			// Lowercase and handle boolean values.
+			val = String(val).toLowerCase();
+			val === 'true' && (val = true);
+			val === 'false' && (val = false);
+
+			// Override prop if env var differs.
+			Env[prop] !== val && (Env[prop] = val);
 		}
 	});
 }
 
 // Set default env based on NODE_ENV/APPC_ENV.
-let setDefaultEnv = _isPreproduction()
-	? 'setPreproduction'
-	: _isEnv('production-eu')
-		? 'setProductionEU'
-		: _isEnv('platform-axway')
-			? 'setPlatformAxway'
-			: 'setProduction';
+let defaultEnv = _getEnvKey();
+Env['set' + defaultEnv]();
 
-Env[setDefaultEnv]();
-_inheritEnvironment();
+// Override props with env vars.
+_inheritEnvVars();

--- a/lib/env.js
+++ b/lib/env.js
@@ -45,6 +45,16 @@ const envs = {
 	}
 };
 
+const platformMap = {
+	baseurl: 'APPC_DASHBOARD_URL',
+	registryurl: 'APPC_REGISTRY_URL',
+	pubsuburl: 'APPC_PUBSUB_URL',
+	webeventurl: 'APPC_WEBEVENT_URL',
+	cacheurl: 'APPC_CACHE_URL',
+	supportUntrusted: 'APPC_SUPPORT_UNTRUSTED',
+	secureCookies: 'APPC_SECURE_COOKIES'
+};
+
 let Env = exports = module.exports = {};
 
 // List env props to wrap with accessors.
@@ -116,6 +126,25 @@ function _isEnv(envs) {
 		|| ~envs.indexOf(process.env.APPC_ENV);
 }
 
+function _inheritEnvironment() {
+	Object.keys(platformMap).forEach(function (prop) {
+		var name = platformMap[prop];
+		var val = process.env[name];
+
+		if (val) {
+			val = val.toLowerCase();
+			if (val === 'true') {
+				val = true;
+			} else if (val === 'false') {
+				val = false;
+			}
+			if (Env[prop] !== val) {
+				Env[prop] = val;
+			}
+		}
+	});
+}
+
 // Set default env based on NODE_ENV/APPC_ENV.
 let setDefaultEnv = _isPreproduction()
 	? 'setPreproduction'
@@ -126,3 +155,4 @@ let setDefaultEnv = _isPreproduction()
 			: 'setProduction';
 
 Env[setDefaultEnv]();
+_inheritEnvironment();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {

--- a/test/env.js
+++ b/test/env.js
@@ -74,4 +74,26 @@ describe('Appc.Env', function () {
 		Appc.cacheurl.should.equal('http://cache.com');
 		Appc.pubsuburl.should.equal('http://pubsub.com');
 	});
+
+	it('should use override with ENV variables', function () {
+		process.env['APPC_DASHBOARD_URL'] = 'http://360-env.appcelerator.com';
+		process.env['APPC_REGISTRY_URL'] = 'http://software-env.appcelerator.com';
+		process.env['APPC_PUBSUB_URL'] = 'http://pubsub-env.appcelerator.com';
+		process.env['APPC_WEBEVENT_URL'] = 'http://webevent-env.appcelerator.com';
+		process.env['APPC_CACHE_URL'] = 'http://webevent-env.appcelerator.com';
+		process.env['APPC_SUPPORT_UNTRUSTED'] = 'false';
+		process.env['APPC_SECURE_COOKIES'] = 'false';
+
+		delete require.cache[require.resolve('../')];
+		delete require.cache[require.resolve('../lib/env')];
+		Appc = require('../');
+
+		Appc.secureCookies.should.equal(false);
+		Appc.supportUntrusted.should.equal(false);
+		Appc.baseurl.should.equal('http://360-env.appcelerator.com');
+		Appc.registryurl.should.equal('http://software-env.appcelerator.com');
+		Appc.pubsuburl.should.equal('http://pubsub-env.appcelerator.com');
+		Appc.webeventurl.should.equal('http://webevent-env.appcelerator.com');
+		Appc.cacheurl.should.equal('http://webevent-env.appcelerator.com');
+	});
 });

--- a/test/env.js
+++ b/test/env.js
@@ -4,96 +4,125 @@ const path = require('path');
 
 const should = require('should');
 
-let Appc;
+let Appc = require('../');
+let currentEnv = {};
 
 describe('Appc.Env', function () {
 
-	beforeEach(function () {
-		Appc = require('../');
-	});
-
-	it('should default env from NODE_ENV or APPC_ENV', function () {
-		if (process.env.NODE_ENV === 'production'
-			|| process.env.APPC_ENV === 'production'
-			|| process.env.NODE_ENV === 'production-eu'
-			|| process.env.APPC_ENV === 'production-eu'
-			|| process.env.NODE_ENV === 'platform-axway'
-			|| process.env.APPC_ENV === 'platform-axway'
-			|| !process.env.NODE_ENV
-			&&  !process.env.APPC_ENV
-		) {
-			Appc.isProduction.should.equal(true);
-		} else {
-			Appc.isProduction.should.equal(false);
-		}
-	});
-
-	it('should be production', function () {
-		Appc.setProduction();
-		Appc.isProduction.should.equal(true);
-	});
-
-	it('should not be production when set to development', function () {
-		Appc.setDevelopment();
-		Appc.isProduction.should.equal(false);
-	});
-
-	it('should not be production when set to local', function () {
-		Appc.setLocal();
-		Appc.isProduction.should.equal(false);
-	});
-
-	it('should be able to be changed', function () {
-		Appc.setDevelopment();
-		Appc.isProduction.should.equal(false);
-		Appc.setProduction();
-		Appc.isProduction.should.equal(true);
-		Appc.setLocal();
-		Appc.isProduction.should.equal(false);
-	});
-
-	it('should allow a custom environment', function () {
-
-		var customEnv = {
-			baseurl: 'http://test.appcelerator.com:8080/Appc',
-			isProduction: false,
-			supportUntrusted: true,
-			registry: 'http://registry.com',
-			webevent: 'http://webevent.com',
-			cache: 'http://cache.com',
-			pubsub: 'http://pubsub.com'
+	before(function (done) {
+		currentEnv = {
+			baseurl: Appc.baseurl,
+			registryurl: Appc.registryurl,
+			pubsuburl: Appc.pubsuburl,
+			webeventurl: Appc.webeventurl,
+			cacheurl: Appc.cacheurl,
+			secureCookies: Appc.secureCookies,
+			supportUntrusted: Appc.supportUntrusted
 		};
-
-		Appc.setEnvironment(customEnv);
-
-		Appc.isProduction.should.equal(false);
-		Appc.supportUntrusted.should.equal(true);
-		Appc.baseurl.should.equal('http://test.appcelerator.com:8080/Appc');
-		Appc.registryurl.should.equal('http://registry.com');
-		Appc.webeventurl.should.equal('http://webevent.com');
-		Appc.cacheurl.should.equal('http://cache.com');
-		Appc.pubsuburl.should.equal('http://pubsub.com');
+		done();
 	});
 
-	it('should use override with ENV variables', function () {
-		process.env['APPC_DASHBOARD_URL'] = 'http://360-env.appcelerator.com';
-		process.env['APPC_REGISTRY_URL'] = 'http://software-env.appcelerator.com';
-		process.env['APPC_PUBSUB_URL'] = 'http://pubsub-env.appcelerator.com';
-		process.env['APPC_WEBEVENT_URL'] = 'http://webevent-env.appcelerator.com';
-		process.env['APPC_CACHE_URL'] = 'http://webevent-env.appcelerator.com';
-		process.env['APPC_SUPPORT_UNTRUSTED'] = 'false';
-		process.env['APPC_SECURE_COOKIES'] = 'false';
+	after(function (done) {
+		Appc.setEnvironment(currentEnv);
+		Appc.baseurl.should.equal(currentEnv.baseurl);
+		Appc.registryurl.should.equal(currentEnv.registryurl);
+		Appc.webeventurl.should.equal(currentEnv.webeventurl);
+		Appc.cacheurl.should.equal(currentEnv.cacheurl);
+		Appc.pubsuburl.should.equal(currentEnv.pubsuburl);
+		Appc.secureCookies.should.equal(currentEnv.secureCookies);
+		Appc.supportUntrusted.should.equal(currentEnv.supportUntrusted);
+		done();
+	});
 
-		delete require.cache[require.resolve('../')];
-		delete require.cache[require.resolve('../lib/env')];
-		Appc = require('../');
+	describe('default environments', function () {
 
-		Appc.secureCookies.should.equal(false);
-		Appc.supportUntrusted.should.equal(false);
-		Appc.baseurl.should.equal('http://360-env.appcelerator.com');
-		Appc.registryurl.should.equal('http://software-env.appcelerator.com');
-		Appc.pubsuburl.should.equal('http://pubsub-env.appcelerator.com');
-		Appc.webeventurl.should.equal('http://webevent-env.appcelerator.com');
-		Appc.cacheurl.should.equal('http://webevent-env.appcelerator.com');
+		it('should default env from NODE_ENV or APPC_ENV', function () {
+			if (process.env.NODE_ENV === 'production'
+				|| process.env.APPC_ENV === 'production'
+				|| process.env.NODE_ENV === 'production-eu'
+				|| process.env.APPC_ENV === 'production-eu'
+				|| process.env.NODE_ENV === 'platform-axway'
+				|| process.env.APPC_ENV === 'platform-axway'
+				|| !process.env.NODE_ENV
+				&&  !process.env.APPC_ENV
+			) {
+				Appc.isProduction.should.equal(true);
+			} else {
+				Appc.isProduction.should.equal(false);
+			}
+		});
+
+		it('should be production', function () {
+			Appc.setProduction();
+			Appc.isProduction.should.equal(true);
+		});
+
+		it('should not be production when set to development', function () {
+			Appc.setDevelopment();
+			Appc.isProduction.should.equal(false);
+		});
+
+		it('should not be production when set to local', function () {
+			Appc.setLocal();
+			Appc.isProduction.should.equal(false);
+		});
+
+		it('should be able to be changed', function () {
+			Appc.setDevelopment();
+			Appc.isProduction.should.equal(false);
+			Appc.setProduction();
+			Appc.isProduction.should.equal(true);
+			Appc.setLocal();
+			Appc.isProduction.should.equal(false);
+		});
+	});
+
+	describe('custom environments', function () {
+
+		it('should allow a custom environment', function () {
+			let customEnv = {
+				baseurl: 'http://test.appcelerator.com:8080/Appc',
+				isProduction: false,
+				supportUntrusted: true,
+				registry: 'http://registry.com',
+				webevent: 'http://webevent.com',
+				cache: 'http://cache.com',
+				pubsub: 'http://pubsub.com'
+			};
+
+			Appc.setEnvironment(customEnv);
+
+			Appc.isProduction.should.equal(false);
+			Appc.supportUntrusted.should.equal(true);
+			Appc.baseurl.should.equal('http://test.appcelerator.com:8080/Appc');
+			Appc.registryurl.should.equal('http://registry.com');
+			Appc.webeventurl.should.equal('http://webevent.com');
+			Appc.cacheurl.should.equal('http://cache.com');
+			Appc.pubsuburl.should.equal('http://pubsub.com');
+		});
+	});
+
+	describe('overrides from process.env', function () {
+
+		it('should use override with ENV variables', function () {
+			process.env.APPC_DASHBOARD_URL = 'http://360-env.appcelerator.com';
+			process.env.APPC_REGISTRY_URL = 'http://software-env.appcelerator.com';
+			process.env.APPC_PUBSUB_URL = 'http://pubsub-env.appcelerator.com';
+			process.env.APPC_WEBEVENT_URL = 'http://webevent-env.appcelerator.com';
+			process.env.APPC_CACHE_URL = 'http://webevent-env.appcelerator.com';
+			process.env.APPC_SUPPORT_UNTRUSTED = 'false';
+			process.env.APPC_SECURE_COOKIES = 'false';
+
+			delete require.cache[require.resolve('../lib/env')];
+			let Env = require('../lib/env');
+
+			Env.secureCookies.should.equal(false);
+			Env.supportUntrusted.should.equal(false);
+			Env.baseurl.should.equal('http://360-env.appcelerator.com');
+			Env.registryurl.should.equal('http://software-env.appcelerator.com');
+			Env.pubsuburl.should.equal('http://pubsub-env.appcelerator.com');
+			Env.webeventurl.should.equal('http://webevent-env.appcelerator.com');
+			Env.cacheurl.should.equal('http://webevent-env.appcelerator.com');
+		});
 	});
 });


### PR DESCRIPTION
Consumes APPC_* env vars needed by CLI for targeting on-premise, so local arrow-admin can reflect correct Dashboard host for unified-nav include.