### PR TITLE
[CLI-1179] Only enable keep-alives when no proxy is detected

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -167,19 +167,20 @@ function _createRequestOpts(session, url, authToken) {
 		headers: {
 			'User-Agent': Appc.userAgent
 		},
-		timeout: 30000,
-		forever: true
+		timeout: 30000
 	};
 
-	if (process.env.APPC_CONFIG_PROXY && process.env.APPC_CONFIG_PROXY !== 'undefined') {
+	if (typeof process.env.APPC_CONFIG_PROXY !== 'undefined') {
 		opts.proxy = process.env.APPC_CONFIG_PROXY;
+	} else {
+		opts.forever = true;
 	}
 
 	if (process.env.APPC_CONFIG_CAFILE) {
 		opts.ca = fs.readFileSync(process.env.APPC_CONFIG_CAFILE);
 	}
 
-	if (process.env.Appc_CONFIG_STRICTSSL === 'false') {
+	if (process.env.APPC_CONFIG_STRICTSSL === 'false') {
 		opts.strictSSL = false;
 	}
 
@@ -188,12 +189,15 @@ function _createRequestOpts(session, url, authToken) {
 		opts.agent = false;
 		opts.rejectUnauthorized = false;
 	}
+
 	if (authToken) {
 		opts.headers['x-auth-token'] = authToken;
 	}
+
 	if (session) {
 		opts.jar = session.jar;
 	}
+
 	debug('fetching', url, 'sid=', session && session.id, 'userAgent=', opts.headers['User-Agent']);
 	return opts;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR attempts to correct an issue where requests in envs with proxies commonly see ECONNRESET errors due to the default use of keep-alives.  It also corrects a bad ref for the strictSSL env var.