### PR TITLE
2.2.0 - [APPTS-9384] add opts arg to App.create/save/updateTiApp functions

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -25,8 +25,9 @@ let App = exports = module.exports = {
 	findAll,
 	findPackage,
 	findTeamMembers,
+	save,
 	update,
-	updateTiApp
+	updateTiApp: save
 };
 
 /**
@@ -71,18 +72,26 @@ function update(session, app, callback) {
 };
 
 /**
- * create or update an application from tiapp.xml file
+ * Create or update an app from tiapp.xml file.
  *
  * @param {Object} session
- * @param {string} file location (path) to tiapp.xml
- * @param {string} orgId if not supplied, use the current logged in org
+ * @param {String} tiAppPath file path of tiapp.xml
+ * @param {String} orgId org_id to register app to; if not supplied, uses logged-in org
+ * @param {Object} opts optional params to pass as query string with app save request
  * @param {Function} callback
  */
-function create(session, tiappxml, orgId, callback) {
-	if (typeof orgId === 'function' || orgId === null) {
-		if (!!orgId) {
-			callback = orgId;
-		}
+function create(session, tiAppPath, orgId, opts, callback) {
+	if (typeof orgId === 'function') {
+		callback = orgId;
+		orgId = null;
+		opts = {};
+	}
+	if (typeof opts === 'function') {
+		callback = opts;
+		opts = {};
+	}
+
+	if (orgId === null) {
 		// use the current session
 		if (session && session.user && session.user.org_id) {
 			orgId = session.user.org_id;
@@ -91,35 +100,56 @@ function create(session, tiappxml, orgId, callback) {
 		}
 	}
 
-	if (!fs.existsSync(tiappxml)) {
+	if (!fs.existsSync(tiAppPath)) {
 		return callback(new Error('tiapp.xml file does not exist'));
 	}
 
-	fs.readFile(tiappxml, function (err, data) {
+	fs.readFile(tiAppPath, function (err, tiappxml) {
 		if (err) {
 			return callback(err);
 		}
-		App.updateTiApp(session, orgId, data, callback);
+		App.save(session, orgId, tiappxml, opts, callback);
 	});
 };
 
-function crittercismID(session, guid, callback) {
-	Appc.createRequest(session, '/api/v1/app/' + guid + '/crittercism_id', callback);
-};
+/**
+ * Create or update an app from tiapp.xml file.
+ *
+ * @param {Object} session
+ * @param {String} orgId if not supplied, use the current logged in org
+ * @param {String} tiappxml contents of tiapp.xml file
+ * @param {Object} opts optional params to pass as query string with app save request
+ * @param {Function} callback
+ */
+function save(session, orgId, tiappxml, opts, callback) {
+	if (typeof opts === 'function') {
+		callback = opts;
+		opts = {};
+	}
 
-function updateTiApp(session, orgId, tiappxml, callback) {
-	var req = Appc.createRequest(session, '/api/v1/app/saveFromTiApp?org_id=' + orgId, 'post', callback);
+	// Form query string with opts.
+	opts.org_id = orgId;
+	let qs = Object.keys(opts).reduce(function (v, k) {
+		return `${v}&${k}=${t[k]}`;
+	}, '');
+
+	let path = `/api/v1/app/saveFromTiApp?${qs}`;
+
+	let req = Appc.createRequest(session, path, 'post', callback);
 	if (req) {
-		var form = req.form();
+		let form = req.form();
 		form.append('tiapp', tiappxml, { filename: 'tiapp.xml' });
 		debug('form parameters for %s, %o', req.uri.href, form);
 	}
 };
 
 /**
- * find an application package by application guid
- * can be called with token or session
- * INTERNAL ONLY
+ * find an application package by application guid; can be called with token or session
+ *
+ * @param {Object} session
+ * @param {String} guid app_guid
+ * @param {String} token session token
+ * @param {Function} callback
  */
 function findPackage(session, guid, token, callback) {
 	if (typeof session === 'string') {
@@ -148,4 +178,14 @@ function findTeamMembers(session, guid, callback) {
  */
 function deleteApp(session, appId, callback) {
 	Appc.createRequest(session, '/api/v1/app/' + appId, 'del', callback);
+};
+
+/**
+ * Fetch Apteligent ID for app.
+ * @param {Object} session
+ * @param {String} guid app guid
+ * @param {Function} callback
+ */
+function crittercismID(session, guid, callback) {
+	Appc.createRequest(session, '/api/v1/app/' + guid + '/crittercism_id', callback);
 };

--- a/lib/app.js
+++ b/lib/app.js
@@ -129,8 +129,8 @@ function save(session, orgId, tiappxml, opts, callback) {
 
 	// Form query string with opts.
 	opts.org_id = orgId;
-	let qs = Object.keys(opts).reduce(function (v, k) {
-		return `${v}&${k}=${t[k]}`;
+	let qs = Object.keys(opts).reduce(function (val, key) {
+		return `${val}&${key}=${opts[key]}`;
 	}, '');
 
 	let path = `/api/v1/app/saveFromTiApp?${qs}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/APPTS-9384

This PR adds a new (optional) `opts` arg to the App.create and App.save/updateTiApp functions to allow appc-cli to pass a flag indicating an `appc new --import` flow.
