### PR TITLE
[CLI-1223] ESOCKETTIMEDOUT when creating acs app from org with vpc env

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,8 +172,7 @@ Appc.createRequestOpts = function (session, url, authToken) {
 		url: url,
 		headers: {
 			'User-Agent': Appc.userAgent
-		},
-		timeout: 30000
+		}
 	};
 
 	if (typeof process.env.APPC_CONFIG_PROXY !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/CLI-1223

It looks like `api/v1/acs` response time is longer than 30 seconds when called from org with vpc environment.

Propose to remove the `timeout` option when making requests.