### PR TITLE
[APPTS-9389] Add unit test to cover auth code rate limiting

### DIFF
--- a/test/analytics.js
+++ b/test/analytics.js
@@ -57,7 +57,7 @@ describe('Appc.Analytics', function () {
 	it('should send analytics data with guid only', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.sendEvent('guid', null, function (err, result, sent) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(sent).be.true;
 			should(result).have.length(1);
@@ -82,7 +82,7 @@ describe('Appc.Analytics', function () {
 	it('should send analytics data with guid and mid only', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.sendEvent('guid', { mid: 'mid' }, function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -106,7 +106,7 @@ describe('Appc.Analytics', function () {
 	it('should send analytics data with guid, mid, eventdata', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.sendEvent('guid', { mid: 'mid', data: { a: 1 } }, function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -130,7 +130,7 @@ describe('Appc.Analytics', function () {
 	it('should send analytics data with guid, mid, eventdata, event', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.sendEvent('guid', { event: 'event', mid: 'mid', data: { a: 1 } }, function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -154,7 +154,7 @@ describe('Appc.Analytics', function () {
 	it('should send analytics data with guid, mid, eventdata, event, deploytype', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.sendEvent('guid', { event: 'event', mid: 'mid', deploytype: 'deploytype', data: { a: 1 } }, function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -178,7 +178,7 @@ describe('Appc.Analytics', function () {
 	it('should send analytics data with guid, mid, eventdata, event, deploytype and sid', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.sendEvent('guid', { event: 'event', mid: 'mid', deploytype: 'deploytype', sid: 'sid-sid-sid-sid-sid-sid', data: { a: 1 } }, function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -203,7 +203,7 @@ describe('Appc.Analytics', function () {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.flushInterval = 1000;
 		notifier = function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -218,7 +218,7 @@ describe('Appc.Analytics', function () {
 	it.skip('should send analytics data immediate', function (done) {
 		should(Appc.Analytics).be.an.object;
 		notifier = function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -232,7 +232,7 @@ describe('Appc.Analytics', function () {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.url = originalUrl;
 		Appc.Analytics.sendEvent(global.$config.apps.enterprise.app_guid, {}, function (err, result, sent) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
@@ -257,7 +257,7 @@ describe('Appc.Analytics', function () {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.flushInterval = 10;
 		notifier = function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(4);
 			should(result[0].data).be.eql({ a: 1 });
@@ -277,7 +277,7 @@ describe('Appc.Analytics', function () {
 		Appc.Analytics.flushInterval = 10;
 		var session;
 		notifier = function (err, result) {
-			should(err).not.be.ok;
+			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(3);
 			should(result[0]).have.property('event', 'ti.start');

--- a/test/app.js
+++ b/test/app.js
@@ -19,7 +19,7 @@ describe('Appc.App', function () {
 
 		Appc.Auth.login(user.username, user.password, function (err, session) {
 			should.not.exist(err);
-			session.should.exist;
+			should.exist(session);
 			currentSession = session;
 			currentSession.isValid().should.equal(true);
 			done();
@@ -30,11 +30,11 @@ describe('Appc.App', function () {
 		Appc.Auth.switchLoggedInOrg(currentSession, global.$config.user.enterprise_org_id, function (err, res, newSession) {
 			currentSession = newSession;
 			should.not.exist(err);
-			newSession.should.exist;
+			should.exist(newSession);
 
 			Appc.App.findAll(currentSession, function (err, apps) {
 				should.not.exist(err);
-				apps.should.exist;
+				should.exist(apps);
 				apps.length.should.not.be.below(global.$config.apps.numberOfApps);
 				done();
 			});
@@ -44,7 +44,7 @@ describe('Appc.App', function () {
 	it('should get all the apps in a specific org', function (done) {
 		Appc.App.findAll(currentSession, global.$config.user.enterprise_org_id, function (err, apps) {
 			should.not.exist(err);
-			apps.should.exist;
+			should.exist(apps);
 			apps.length.should.not.be.below(global.$config.apps.numberOfApps);
 			done();
 		});
@@ -52,7 +52,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find apps in an org that the user doesnt have access to', function (done) {
 		Appc.App.findAll(currentSession, 123, function (err, apps) {
-			err.should.exist;
+			should.exist(err);
 			err.code.should.equal(403);
 			err.message.should.equal('You do not have access privileges to view this content.');
 			should.not.exist(apps);
@@ -62,7 +62,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find apps with an invalid session', function (done) {
 		Appc.App.findAll({}, 123, function (err) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('session is not valid');
 			done();
 		});
@@ -71,7 +71,7 @@ describe('Appc.App', function () {
 	it('should find a specific app by ID', function (done) {
 		Appc.App.find(currentSession, global.$config.apps.enterprise.app_id, function (err, app) {
 			should.not.exist(err);
-			app.should.exist;
+			should.exist(app);
 			app.app_name.should.equal(global.$config.apps.enterprise.app_name);
 			done();
 		});
@@ -79,7 +79,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find an invalid app by ID', function (done) {
 		Appc.App.find(currentSession, 1, function (err, app) {
-			err.should.exist;
+			should.exist(err);
 			should.not.exist(app);
 			done();
 		});
@@ -87,7 +87,7 @@ describe('Appc.App', function () {
 
 	it('should fail to a valid app with an invalid session', function (done) {
 		Appc.App.find({}, global.$config.apps.enterprise.app_id, function (err) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('session is not valid');
 			done();
 		});
@@ -98,7 +98,7 @@ describe('Appc.App', function () {
 			let originalName = global.$config.apps.enterprise.app_name;
 			let newName = global.$config.apps.enterprise.app_name + '_modified';
 			should.not.exist(err);
-			app.should.exist;
+			should.exist(app);
 			app.app_name.should.equal(originalName);
 			app.app_name = newName;
 
@@ -107,7 +107,7 @@ describe('Appc.App', function () {
 
 				Appc.App.find(currentSession, global.$config.apps.enterprise.app_id, function (err, updatedApp) {
 					should.not.exist(err);
-					app.should.exist;
+					should.exist(app);
 					updatedApp.app_name.should.equal(newName);
 					updatedApp.app_name = originalName;
 
@@ -116,7 +116,7 @@ describe('Appc.App', function () {
 
 						Appc.App.find(currentSession, global.$config.apps.enterprise.app_id, function (err, revertedApp) {
 							should.not.exist(err);
-							revertedApp.should.exist;
+							should.exist(revertedApp);
 							revertedApp.app_name.should.equal(originalName);
 							done();
 						});
@@ -134,11 +134,11 @@ describe('Appc.App', function () {
 			app_guid: 1234567890
 		};
 		Appc.App.find(currentSession, newApp, function (err, app) {
-			err.should.exist;
+			should.exist(err);
 			should.not.exist(app);
 
 			Appc.App.update(currentSession, newApp, function (err) {
-				err.should.exist;
+				should.exist(err);
 				done();
 			});
 		});
@@ -147,10 +147,10 @@ describe('Appc.App', function () {
 	it('should fail to update an app with an invalid session', function (done) {
 		Appc.App.find(currentSession, global.$config.apps.enterprise.app_id, function (err, app) {
 			should.not.exist(err);
-			app.should.exist;
+			should.exist(app);
 
 			Appc.App.update({}, app, function (err) {
-				err.should.exist;
+				should.exist(err);
 				err.message.should.equal('session is not valid');
 				done();
 			});
@@ -159,7 +159,7 @@ describe('Appc.App', function () {
 
 	it('should fail to update an invalid app', function (done) {
 		Appc.App.update(currentSession, {}, function (err) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('no app_guid property found');
 			done();
 		});
@@ -167,7 +167,7 @@ describe('Appc.App', function () {
 
 	it('should fail to create an app from non-existent tiapp.xml', function (done) {
 		Appc.App.create(currentSession, path.join(__dirname, 'tiapptest0', 'none.xml'), global.$config.user.enterprise_org_id, function (err, app) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('tiapp.xml file does not exist');
 			should.not.exist(app);
 			done();
@@ -177,7 +177,7 @@ describe('Appc.App', function () {
 	it('should create an app from provided tiapp.xml', function (done) {
 		Appc.App.create(currentSession, path.join(__dirname, 'tiapptest1', 'tiapp.xml'), global.$config.user.enterprise_org_id, function (err, app) {
 			should.not.exist(err);
-			app.should.exist;
+			should.exist(app);
 
 			Appc.App.delete(currentSession, app._id, function (err) {
 				should.not.exist(err);
@@ -189,7 +189,7 @@ describe('Appc.App', function () {
 	it('should create an app from provided tiapp.xml with no org id', function (done) {
 		Appc.App.create(currentSession, path.join(__dirname, 'tiapptest1', 'tiapp.xml'), function (err, app) {
 			should.not.exist(err);
-			app.should.exist;
+			should.exist(app);
 
 			Appc.App.delete(currentSession, app._id, function (err) {
 				should.not.exist(err);
@@ -200,7 +200,7 @@ describe('Appc.App', function () {
 
 	it('should fail create an app from provided tiapp.xml with no org id and invalid session', function (done) {
 		Appc.App.create({}, path.join(__dirname, 'tiapptest1', 'tiapp.xml'), function (err, app) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('session is not valid');
 			should.not.exist(app);
 			done();
@@ -210,7 +210,7 @@ describe('Appc.App', function () {
 	it('should create an app from provided tiapp.xml with a null org id', function (done) {
 		Appc.App.create(currentSession, path.join(__dirname, 'tiapptest1', 'tiapp.xml'), null, function (err, app) {
 			should.not.exist(err);
-			app.should.exist;
+			should.exist(app);
 
 			Appc.App.delete(currentSession, app._id, function (err) {
 				should.not.exist(err);
@@ -222,20 +222,20 @@ describe('Appc.App', function () {
 	it('should update an app from provided tiapp.xml', function (done) {
 		Appc.App.create(currentSession, path.join(__dirname, 'tiapptest2', 'tiapp.xml'), global.$config.user.enterprise_org_id, function (err, app) {
 			should.not.exist(err);
-			app.should.exist;
+			should.exist(app);
 
 			Appc.App.find(currentSession, app._id, function (err, app) {
 				should.not.exist(err);
-				app.should.exist;
+				should.exist(app);
 				app.app_name.should.equal('TiAppTest2_changeme');
 
 				Appc.App.create(currentSession, path.join(__dirname, 'tiapptest2', 'tiapp_changed.xml'), global.$config.user.enterprise_org_id, function (err, app2) {
 					should.not.exist(err);
-					app2.should.exist;
+					should.exist(app2);
 
 					Appc.App.find(currentSession, app2._id, function (err, changedApp) {
 						should.not.exist(err);
-						changedApp.should.exist;
+						should.exist(changedApp);
 						changedApp.app_name.should.equal('TiAppTest2');
 
 						Appc.App.delete(currentSession, changedApp._id, function (err) {
@@ -250,7 +250,7 @@ describe('Appc.App', function () {
 
 	it('should fail to create an app from invalid tiapp.xml', function (done) {
 		Appc.App.create(currentSession, path.join(__dirname, 'tiapptest3', 'tiapp.xml'), global.$config.user.enterprise_org_id, function (err, app) {
-			err.should.exist;
+			should.exist(err);
 			err.code.should.equal(500);
 			should.not.exist(app);
 			done();
@@ -259,7 +259,7 @@ describe('Appc.App', function () {
 
 	it('should fail to create an app from invalid session', function (done) {
 		Appc.App.create({}, path.join(__dirname, 'tiapptest1', 'tiapp.xml'), global.$config.user.enterprise_org_id, function (err, app) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('session is not valid');
 			should.not.exist(app);
 			done();
@@ -268,7 +268,7 @@ describe('Appc.App', function () {
 
 	it('should fail to create a tiapp.xml app with invalid org id', function (done) {
 		Appc.App.create(currentSession, path.join(__dirname, 'tiapptest1', 'tiapp.xml'), 123, function (err, app) {
-			err.should.exist;
+			should.exist(err);
 			err.code.should.equal(404);
 			should.not.exist(app);
 			done();
@@ -278,7 +278,7 @@ describe('Appc.App', function () {
 	it('should find an enterprise package by application guid and session', function (done) {
 		Appc.App.findPackage(currentSession, global.$config.apps.enterprise.app_guid, function (err, res) {
 			should.not.exist(err);
-			res.should.exist;
+			should.exist(res);
 			res.package.should.equal('enterprise');
 			res.isPlatform.should.equal(true);
 			done();
@@ -288,7 +288,7 @@ describe('Appc.App', function () {
 	it('should find an enterprise package by application guid and token', function (done) {
 		Appc.App.findPackage(currentSession, global.$config.apps.enterprise.app_guid, global.$config.auth_token, function (err, res) {
 			should.not.exist(err);
-			res.should.exist;
+			should.exist(res);
 			res.package.should.equal('enterprise');
 			res.isPlatform.should.equal(true);
 			done();
@@ -297,7 +297,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find an enterprise package by application guid and invalid session', function (done) {
 		Appc.App.findPackage({}, global.$config.apps.enterprise.app_guid, function (err, res) {
-			err.should.exist;
+			should.exist(err);
 			should.not.exist(res);
 			err.message.should.equal('session is not valid');
 			done();
@@ -306,7 +306,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find an application package by invalid application guid and session', function (done) {
 		Appc.App.findPackage(currentSession, '123', function (err, res) {
-			err.should.exist;
+			should.exist(err);
 			should.exist(err.code);
 			err.code.should.be.greaterThan(400);
 			should.not.exist(res);
@@ -317,7 +317,7 @@ describe('Appc.App', function () {
 	it('should find a free application package by application guid and session', function (done) {
 		Appc.App.findPackage(currentSession, global.$config.apps.developer.app_guid, function (err, res) {
 			should.not.exist(err);
-			res.should.exist;
+			should.exist(res);
 			res.isPlatform.should.equal(false);
 			res.package.should.equal('free');
 			done();
@@ -327,8 +327,8 @@ describe('Appc.App', function () {
 	it('should find the team members of an app', function (done) {
 		Appc.App.findTeamMembers(currentSession, global.$config.apps.enterprise.app_id, function (err, res) {
 			should.not.exist(err);
-			res.should.exist;
-			res.members.should.exist;
+			should.exist(res);
+			res.should.exist(members);
 			res.members.length.should.equal(1);
 			res.members[0].guid.should.equal(currentSession.user.guid);
 			done();
@@ -337,7 +337,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find the team members of an invalid app', function (done) {
 		Appc.App.findTeamMembers(currentSession, '123', function (err, res) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('Resource Not Found');
 			err.code.should.equal(404);
 			should.not.exist(res);
@@ -347,7 +347,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find the team members of an app with an invalid session', function (done) {
 		Appc.App.findTeamMembers({}, global.$config.apps.enterprise.app_id, function (err, res) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('session is not valid');
 			should.not.exist(res);
 			done();
@@ -356,7 +356,7 @@ describe('Appc.App', function () {
 
 	it('should fail to find the team members of an app with an invalid session', function (done) {
 		Appc.App.findTeamMembers({}, global.$config.apps.enterprise.app_id, function (err, res) {
-			err.should.exist;
+			should.exist(err);
 			err.message.should.equal('session is not valid');
 			should.not.exist(res);
 			done();
@@ -366,14 +366,14 @@ describe('Appc.App', function () {
 	it('should get the crittercism ID of an enterprise app', function (done) {
 		Appc.App.crittercismID(currentSession, global.$config.apps.enterprise.app_id, function (err, id) {
 			should.not.exist(err);
-			id.should.exist;
+			should.exist(id);
 			done();
 		});
 	});
 
 	it('should fail to get the crittercism ID of an enterprise app with invalid session', function (done) {
 		Appc.App.crittercismID({}, global.$config.apps.enterprise.app_id, function (err, id) {
-			err.should.exist;
+			should.exist(err);
 			should.not.exist(id);
 			done();
 		});

--- a/test/auth.js
+++ b/test/auth.js
@@ -129,6 +129,54 @@ describe('Appc.Auth', function () {
 			});
 		});
 
+		it('should get locked out of auth code generation after multiple attempts', function (done) {
+			should.exist(currentSession);
+
+			Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
+				should.not.exist(err);
+				should.exist(res);
+
+				Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
+					should.not.exist(err);
+					should.exist(res);
+
+					Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
+						should.not.exist(err);
+						should.exist(res);
+
+						Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
+							should.exist(err);
+							should.not.exist(res);
+
+							done();
+						});
+					});
+				});
+			});
+		});
+
+		it('should be able to request another auth code after valid auth code entry', function (done) {
+			should.exist(currentSession);
+
+			helper.getAuthCode('sms', function (err, res) {
+				should.not.exist(err);
+				should.exist(res);
+
+				Appc.Auth.verifyLoginCode(currentSession, res, function (err, res) {
+					should.not.exist(err);
+					should.exist(res);
+					res.should.equal(true);
+
+					Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
+						should.not.exist(err);
+						should.exist(res);
+
+						done();
+					});
+				});
+			});
+		});
+
 		it('should be able to request an email auth code with a valid session', function (done) {
 			should.exist(currentSession);
 

--- a/test/auth.js
+++ b/test/auth.js
@@ -78,7 +78,7 @@ describe('Appc.Auth', function () {
 			});
 		});
 
-		it.skip('should verify the email auth code that was requested earlier', function (done) {
+		it('should verify the email auth code that was requested earlier', function (done) {
 			helper.getAuthCode('email', function (err, res) {
 				should.not.exist(err);
 				res.should.exist;
@@ -115,7 +115,7 @@ describe('Appc.Auth', function () {
 			});
 		});
 
-		it.skip('should verify the sms auth code that was requested earlier', function (done) {
+		it('should verify the sms auth code that was requested earlier', function (done) {
 			helper.getAuthCode('sms', function (err, res) {
 				should.not.exist(err);
 				res.should.exist;

--- a/test/auth.js
+++ b/test/auth.js
@@ -23,7 +23,7 @@ describe('Appc.Auth', function () {
 		it('fake user should not be able to log in', function (done) {
 			var fakeuser = helper.fakeUser;
 			Appc.Auth.login(fakeuser.username, fakeuser.password, function (err, result) {
-				err.should.exist;
+				should.exist(err);
 				should.not.exist(result);
 				done();
 			});
@@ -33,7 +33,7 @@ describe('Appc.Auth', function () {
 			var user = global.$config.user;
 			Appc.Auth.login(user.username, user.password, function (err, result) {
 				should.not.exist(err);
-				result.should.exist;
+				should.exist(result);
 				currentSession = result;
 				done();
 			});
@@ -44,7 +44,7 @@ describe('Appc.Auth', function () {
 			var params = { username: user.username, password: user.password };
 			Appc.Auth.login(params, function (err, result) {
 				should.not.exist(err);
-				result.should.exist;
+				should.exist(result);
 				currentSession = result;
 				done();
 			});
@@ -59,7 +59,7 @@ describe('Appc.Auth', function () {
 			should.exist(currentSession);
 			Appc.Auth.requestLoginCode(currentSession, false, function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 				done();
 			});
 		});
@@ -71,7 +71,7 @@ describe('Appc.Auth', function () {
 			invalidSession.isValid().should.equal(false);
 
 			Appc.Auth.requestLoginCode(invalidSession, false, function (err) {
-				err.should.exist;
+				should.exist(err);
 				err.should.have.property('message');
 				err.message.should.equal('session is not valid');
 				done();
@@ -81,11 +81,11 @@ describe('Appc.Auth', function () {
 		it('should verify the email auth code that was requested earlier', function (done) {
 			helper.getAuthCode('email', function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 
 				Appc.Auth.verifyLoginCode(currentSession, res, function (err, res) {
 					should.not.exist(err);
-					res.should.exist;
+					should.exist(res);
 					res.should.equal(true);
 					done();
 				});
@@ -97,7 +97,7 @@ describe('Appc.Auth', function () {
 
 			Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 				done();
 			});
 		});
@@ -108,7 +108,7 @@ describe('Appc.Auth', function () {
 			invalidSession.isValid().should.equal(false);
 
 			Appc.Auth.requestLoginCode(invalidSession, true, function (err) {
-				err.should.exist;
+				should.exist(err);
 				err.should.have.property('message');
 				err.message.should.equal('session is not valid');
 				done();
@@ -118,11 +118,11 @@ describe('Appc.Auth', function () {
 		it('should verify the sms auth code that was requested earlier', function (done) {
 			helper.getAuthCode('sms', function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 
 				Appc.Auth.verifyLoginCode(currentSession, res, function (err, res) {
 					should.not.exist(err);
-					res.should.exist;
+					should.exist(res);
 					res.should.equal(true);
 					done();
 				});
@@ -134,14 +134,14 @@ describe('Appc.Auth', function () {
 
 			Appc.Auth.requestLoginCode(currentSession, false, function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 				done();
 			});
 		});
 
 		it('should fail to verify an invalid auth code', function (done) {
 			Appc.Auth.verifyLoginCode(currentSession, 123, function (err, res) {
-				err.should.exist;
+				should.exist(err);
 				should.not.exist(res);
 				err.message.should.equal('Your authorization code was invalid.');
 				done();
@@ -150,7 +150,7 @@ describe('Appc.Auth', function () {
 
 		it('should fail to verify an auth code with an invalid session', function (done) {
 			Appc.Auth.verifyLoginCode({}, 1234, function (err, res) {
-				err.should.exist;
+				should.exist(err);
 				should.not.exist(res);
 				done();
 			});
@@ -187,7 +187,7 @@ describe('Appc.Auth', function () {
 		});
 
 		it('should fail if user tries to log out with an invalid session', function (done) {
-			currentSession.should.exist;
+			should.exist(currentSession);
 			var invalidSession = helper.cloneSession(currentSession);
 			invalidSession.invalidate();
 			// try an invalidate again to get more code coverage
@@ -195,7 +195,7 @@ describe('Appc.Auth', function () {
 			invalidSession.isValid().should.equal(false);
 
 			Appc.Auth.logout(invalidSession, function (err) {
-				err.should.exist;
+				should.exist(err);
 				err.should.have.property('message');
 				err.message.should.equal('session is not valid');
 				done();
@@ -216,7 +216,7 @@ describe('Appc.Auth', function () {
 
 		it('should fail to create a session from invalid ID', function (done) {
 			Appc.Auth.createSessionFromID('1234', function (err, session) {
-				err.should.exist;
+				should.exist(err);
 				should.not.exist(session);
 				should.exist(err.message);
 				err.message.should.equal('invalid session');
@@ -229,7 +229,7 @@ describe('Appc.Auth', function () {
 				password = global.$config.user.password;
 			helper.cliLogin(username, password, function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 				should.exist(res.id);
 				Appc.Auth.createSessionFromID(res.id, function (err, session) {
 					should.not.exist(err);
@@ -259,7 +259,7 @@ describe('Appc.Auth', function () {
 		it('should validate the session previously created', function (done) {
 			Appc.Auth.validateSession(createdSession, function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 				done();
 			});
 		});
@@ -267,7 +267,7 @@ describe('Appc.Auth', function () {
 		it('should get a cached session from createSessionFromID', function (done) {
 			Appc.Auth.createSessionFromID(createdSession.id, function (err, res) {
 				should.not.exist(err);
-				res.should.exist;
+				should.exist(res);
 				res.should.equal(createdSession);
 				done();
 			});
@@ -277,7 +277,7 @@ describe('Appc.Auth', function () {
 			createdSession.invalidate(function (err) {
 				should.not.exist(err);
 				Appc.Auth.validateSession(createdSession, function (err, res) {
-					err.should.exist;
+					should.exist(err);
 					should.not.exist(res);
 					createdSession = null;
 					done();

--- a/test/auth.js
+++ b/test/auth.js
@@ -252,12 +252,12 @@ describe('Appc.Auth', function () {
 
 		it('should be able to log out from valid session', function (done) {
 			should.exist(currentSession);
-			should(currentSession).be.ok;
+			should(currentSession).be.ok();
 			currentSession.isValid().should.equal(true);
 			Appc.Auth.logout(currentSession, function (err) {
 				should.not.exist(err);
 				currentSession = undefined;
-				should(currentSession).not.be.ok;
+				should(currentSession).not.be.ok();
 				done();
 			});
 		});

--- a/test/cloud.js
+++ b/test/cloud.js
@@ -19,7 +19,7 @@ describe('Appc.Cloud', function () {
 
 		Appc.Auth.login(user.username, user.password, function (err, session) {
 			should.not.exist(err);
-			session.should.exist;
+			should.exist(session);
 			currentSession = session;
 			currentSession.isValid().should.equal(true);
 			done();

--- a/test/cloud.js
+++ b/test/cloud.js
@@ -32,7 +32,7 @@ describe('Appc.Cloud', function () {
 		before(function (done) {
 			var user = global.$config.user;
 			Appc.Auth.login(user.username, user.password, function (err, result) {
-				should(result).be.ok;
+				should(result).be.ok();
 				should.not.exist(err);
 				should.exist(result);
 				currentSession = result;

--- a/test/feed.js
+++ b/test/feed.js
@@ -15,7 +15,7 @@ describe('Appc.Feed', function () {
 
 		Appc.Auth.login(user.username, user.password, function (err, session) {
 			should.not.exist(err);
-			session.should.exist;
+			should.exist(session);
 			currentSession = session;
 			currentSession.isValid().should.equal(true);
 			done();

--- a/test/lib/helper.js
+++ b/test/lib/helper.js
@@ -107,8 +107,8 @@ function getAuthCode(method, callback) {
 					return callback(err);
 				}
 				retryGetLastEmail(15000, 20, function (err, email) {
-					if (email && email.html && email.html.match(/Authorization Code: <b>([0-9]{4})/)) {
-						return callback(null, email.html.match(/Authorization Code: <b>([0-9]{4})/)[1]);
+					if (email && email.html && email.html.match(/Authorization Code: <b>(\w{6})/)) {
+						return callback(null, email.html.match(/Authorization Code: <b>(\w{6})/)[1]);
 					} else {
 						return callback(err || 'No email found');
 					}
@@ -209,7 +209,7 @@ function getLastSMS(callback) {
 		for (var c = 0; c < results.sms_messages.length; c++) {
 			var message = results.sms_messages[c];
 			if (message.direction === 'inbound') {
-				var match = (/Appcelerator (device|phone) (authorization|verification) code: (\d{4})/).exec(message.body);
+				var match = (/Appcelerator (device|phone) (authorization|verification) code: (\w{6})/).exec(message.body);
 				if (match && match.length) {
 					return callback(null, match[3]);
 				}

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -69,7 +69,7 @@ describe('middleware', function () {
 			resp.send('OK');
 		});
 		request.get('http://127.0.0.1:' + server.port + '/', function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(body).be.equal('OK');
 			should(resp.statusCode).be.equal(200);
 			done();
@@ -87,7 +87,7 @@ describe('middleware', function () {
 			resp.send(req.session && req.session.user ? 'FAILED' : 'OK');
 		});
 		request.get('http://127.0.0.1:' + server.port + '/', function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(body).be.equal('OK');
 			should(resp.statusCode).be.equal(200);
 			done();
@@ -107,7 +107,7 @@ describe('middleware', function () {
 			followRedirect: false
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(302);
 			should(body).match(new RegExp('Redirecting to ' + Appc.baseurl));
 			done();
@@ -129,7 +129,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(401);
 			should(body).be.empty;
 			done();
@@ -151,7 +151,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(401);
 			should(body).be.empty;
 			done();
@@ -173,7 +173,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(401);
 			should(body).be.eql(JSON.stringify({
 				success: false,
@@ -203,7 +203,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(401);
 			should(body).be.eql(JSON.stringify({
 				success: false,
@@ -234,7 +234,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(401);
 			should(body).be.eql(JSON.stringify({
 				success: false,
@@ -265,7 +265,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(401);
 			should(body).be.eql(JSON.stringify({
 				success: false,
@@ -299,7 +299,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(200);
 			should(body).be.eql(JSON.stringify({
 				success: false
@@ -332,7 +332,7 @@ describe('middleware', function () {
 			}
 		};
 		request.get(opts, function (err, resp, body) {
-			should(err).be.not.ok;
+			should(err).be.not.ok();
 			should(resp.statusCode).be.equal(401);
 			done();
 		});
@@ -375,7 +375,7 @@ describe('middleware', function () {
 				isNew: true
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(200);
 				should(resp.headers).have.property('set-cookie');
 				should(resp.headers['set-cookie'][0]).match(/^session=/);
@@ -386,10 +386,10 @@ describe('middleware', function () {
 				should(jar._jar.store.idx['127.0.0.1']['/']).have.property('session');
 				should(jar._jar.store.idx['127.0.0.1']['/']).have.property('session.sig');
 				request(opts, function (err, resp, body) {
-					should(err).be.not.ok;
+					should(err).be.not.ok();
 					should(resp.statusCode).be.equal(200);
 					var data = JSON.parse(body);
-					should(data.user).be.ok;
+					should(data.user).be.ok();
 					should(data.user._id).be.equal(obj.user._id);
 					should(data.isNew).be.equal(false);
 					done();
@@ -443,7 +443,7 @@ describe('middleware', function () {
 				revalidated: false
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(200);
 				should(resp.headers).have.property('set-cookie');
 				should(resp.headers['set-cookie'][0]).match(/^session=/);
@@ -454,10 +454,10 @@ describe('middleware', function () {
 				should(jar._jar.store.idx['127.0.0.1']['/']).have.property('session');
 				should(jar._jar.store.idx['127.0.0.1']['/']).have.property('session.sig');
 				request(opts, function (err, resp, body) {
-					should(err).be.not.ok;
+					should(err).be.not.ok();
 					should(resp.statusCode).be.equal(200);
 					var data = JSON.parse(body);
-					should(data.user).be.ok;
+					should(data.user).be.ok();
 					should(data.user._id).be.equal(obj.user._id);
 					should(data.isNew).be.equal(false);
 					should(data.revalidated).be.equal(true);
@@ -471,7 +471,7 @@ describe('middleware', function () {
 		should(Appc.Middleware).be.an.object;
 		var middleware = new Appc.Middleware({
 			successHandler: function (req, resp, next, session, revalidated) {
-				should(session).be.ok;
+				should(session).be.ok();
 				should(session).be.eql({
 					'_id':'54d53480b867bc232dc3ea1d',
 					user_id:1503110,
@@ -502,7 +502,7 @@ describe('middleware', function () {
 				}
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(200);
 				should(body).eql(JSON.stringify({
 					success: true,
@@ -531,7 +531,7 @@ describe('middleware', function () {
 				}
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(401);
 				should(body).be.equal('{"success":false,"code":401,"message":"unauthorized","error":"insufficient privilieges based on your subscription"}');
 				done();
@@ -560,7 +560,7 @@ describe('middleware', function () {
 				followRedirect: false
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(401);
 				should(body).be.equal(JSON.stringify({
 					success:false,
@@ -594,7 +594,7 @@ describe('middleware', function () {
 				followRedirect: false
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(200);
 				should(body).be.equal('OK');
 				done();
@@ -622,7 +622,7 @@ describe('middleware', function () {
 				followRedirect: false
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(200);
 				should(body).be.equal('OK');
 				done();
@@ -647,14 +647,14 @@ describe('middleware', function () {
 				}
 			};
 			request(opts, function (err, resp, body) {
-				should(err).be.not.ok;
+				should(err).be.not.ok();
 				should(resp.statusCode).be.equal(200);
 				should(body).be.equal(session.id);
 				Appc.Auth.login(global.$config.user.username, global.$config.user.password, function (err, session) {
 					// change the sid and it should generate a new session login
 					opts.headers.cookie = 'connect.sid=' + encodeURIComponent(session.id);
 					request(opts, function (err, resp, body) {
-						should(err).be.not.ok;
+						should(err).be.not.ok();
 						should(resp.statusCode).be.equal(200);
 						should(body).be.equal(session.id);
 						done();

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -24,14 +24,14 @@ describe('middleware', function () {
 
 		Appc.Auth.login(user.username, user.password, function (err, session) {
 			should.not.exist(err);
-			session.should.exist;
+			should.exist(session);
 			currentSession = session;
 			currentSession.isValid().should.equal(true);
 
 			Appc.Auth.switchLoggedInOrg(currentSession, global.$config.user.enterprise_org_id, function (err, res, newSession) {
 				currentSession = newSession;
 				should.not.exist(err);
-				newSession.should.exist;
+				should.exist(newSession);
 				done();
 			});
 		});

--- a/test/notification.js
+++ b/test/notification.js
@@ -15,7 +15,7 @@ describe('Appc.Notification', function () {
 
 		Appc.Auth.login(user.username, user.password, function (err, session) {
 			should.not.exist(err);
-			session.should.exist;
+			should.exist(session);
 			currentSession = session;
 			currentSession.isValid().should.equal(true);
 			done();

--- a/test/org.js
+++ b/test/org.js
@@ -16,7 +16,7 @@ describe('Appc.Org', function () {
 
 		Appc.Auth.login(user.username, user.password, function (err, session) {
 			should.not.exist(err);
-			session.should.exist;
+			should.exist(session);
 			currentSession = session;
 			currentSession.isValid().should.equal(true);
 

--- a/test/user.js
+++ b/test/user.js
@@ -15,7 +15,7 @@ describe('Appc.User', function () {
 
 		Appc.Auth.login(user.username, user.password, function (err, session) {
 			should.not.exist(err);
-			session.should.exist;
+			should.exist(session);
 			currentSession = session;
 			currentSession.isValid().should.equal(true);
 			done();


### PR DESCRIPTION
https://jira.appcelerator.org/browse/APPTS-9389

This PR adds two additional tests to the auth unit test which cover auth code request restrictions, and auth code restriction unlocking.
Also included are support for the updated auth code formatting, and fixes for the usage of `should.exist` and `should.be(.not).ok`.

Verification
---
Run `NODE_ENV=development mocha test/auth.js` and make sure the tests are all passing