### PR TITLE
[APPTS-9539] Strip out synchronous functions, refactor analytics interfaces

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -42,8 +42,8 @@ let Analytics = exports = module.exports = {
 	analyticsDirectory: ANALYTICS_DIR,
 	createSession,
 	sendEvent,
-	startFlushTask,
-	stopFlushTask,
+	flush,
+	stopFlush,
 	url
 };
 
@@ -149,7 +149,7 @@ function sendEvent(app_guid, event_name, props, callback, immediate) {
 	}
 
 	// start sending events (if not already running)
-	startFlushTask();
+	flush();
 
 	// pass back payload, false means not immediately sent
 	finished(null, [ event ], false);
@@ -161,16 +161,16 @@ function sendEvent(app_guid, event_name, props, callback, immediate) {
  * This is a timeout rather than an interval to control
  * the async behaviour of the triggered flush.
  */
-function startFlushTask() {
-	debug('startFlushTask');
+function flush() {
+	debug('flush');
 	!timeout && (timeout = setTimeout(flushEvents, flushInterval));
 }
 
 /**
  * Cancels a flush schedule if one is running.
  */
-function stopFlushTask() {
-	debug('stopFlushTask');
+function stopFlush() {
+	debug('stopFlush');
 	timeout && clearTimeout(timeout);
 	timeout = undefined;
 }
@@ -249,9 +249,7 @@ function appendPayload(payload, callback) {
 function flushEvents(callback) {
 	// attach a hook to log errors if missing callback
 	function finished(err, data, sent, cancel) {
-		if (!cancel) {
-			startFlushTask();
-		}
+		!cancel && flush();
 		if (callback) {
 			return callback(err, data, sent);
 		}

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -39,7 +39,7 @@ const flushInterval = 10000;
 
 // exports definitions, other stuff is private
 let Analytics = exports = module.exports = {
-	analyticsDirectory: ANALYTICS_DIR,
+	ANALYTICS_DIR: ANALYTICS_DIR,
 	createSession,
 	sendEvent,
 	flush,

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const async = require('async');
 const debug = require('debug')('Appc:sdk:analytics');
 const request = require('request');
 const uuid = require('uuid/v4');
@@ -21,7 +22,7 @@ const Appc = require('.');
 /**
  * default location of the analytics cache
  */
-const analyticsDir = path.join(os.homedir && os.homedir() || process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE || '/tmp', '.appc-analytics');
+const ANALYTICS_DIR = path.join(os.homedir && os.homedir() || process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE || '/tmp', '.appc-analytics');
 
 /**
  * URL for sending data
@@ -29,156 +30,82 @@ const analyticsDir = path.join(os.homedir && os.homedir() || process.env.HOME ||
 const url = Appc.analyticsurl;
 
 /**
- * the interval in ms to send analytics. If set to 0, always send immediately.
+ * The interval in ms to send analytics.
+ *
+ * This should not be set to a lower number, as we're using
+ * an interval which does not wait for flush completion.
  */
 const flushInterval = 10000;
 
+// exports definitions, other stuff is private
 let Analytics = exports = module.exports = {
-	analyticsDir,
+	analyticsDirectory: ANALYTICS_DIR,
 	createSession,
-	flushEvents,
-	flushInterval,
 	sendEvent,
-	startSendingEvents,
-	stopSendingEvents,
-	storeEvent,
+	startFlushTask,
+	stopFlushTask,
 	url
 };
 
-let timer;
-let sending;
-let sequence = 1;
+// global timeout ref
+let timeout;
 
 /**
- * store an event in the internal store ready to be sent
- * @private
+ * Creates a new analytics session and triggers the
+ * session start event.
+ *
+ * This will return a new Session object which contains
+ * the `end` method to invoke when the session is over.
+ *
+ * @param {string} app_guid
+ * 		the application guid identifier.
+ * @param {string} mid
+ * 		the machine identifier for this device.
+ * @param {string} deploytype
+ * 		the deployment environment for this session.
+ * @param {string} platform
+ *		the platform this session is running on.
+ * @param {object} data
+ * 		arbitrary data to store alongside the session.
+ * @returns
+ * 		a new Session instance.
  */
-function storeEvent(obj) {
-	!fs.existsSync(analyticsDir) && fs.mkdirSync(analyticsDir);
-	let fn = path.join(analyticsDir, Math.floor(Date.now()) + '-' + obj.seq + '-' + obj.id + '.json');
-	debug('store event', obj, fn);
-	fs.writeFileSync(fn, JSON.stringify(obj));
+function createSession(app_guid, mid, deploytype, platform, data) {
+	return new Session(app_guid, mid, deploytype, platform).start(data);
 }
 
 /**
- * flush pending events to analytics
- * @private
+ * Sends a new event payload to the analytics endpoint.
+ *
+ * Accepts a flag to send immediately, otherwise fired
+ * on interval.
+ *
+ * @param {string} app_guid
+ * 		the application guid identifier.
+ * @param {string} event_name
+ * 		the event name to set against the event.
+ * @param {object} props
+ * 		arbitrary properties to attach to the payload.
+ * @param {function} [callback]
+ * 		optional callback to fire on completion.
+ * @param {boolean} [immediate=false]
+ * 		optional flag to fire events immediately.
+ * @return {undefined}
  */
-function flushEvents(callback) {
-	debug('flushEvents', fs.existsSync(analyticsDir), 'sending', sending);
-	if (fs.existsSync(analyticsDir) && !sending) {
-		let files = fs.readdirSync(analyticsDir);
-		if (files.length) {
-			sending = true;
-			// sort them in timestamp order
-			files.sort();
-			let data = files.map(function (fn) {
-				let buf = fs.readFileSync(path.join(analyticsDir, fn));
-				return JSON.parse(buf);
-			});
-			let opts = {
-				url: url,
-				method: 'POST',
-				json: data,
-				timeout: 30000
-			};
-			debug('flushEvents sending', opts);
-			return request(opts, function (err, resp, body) {
-				sending = false;
-				debug('flushEvents response', err, resp && resp.statusCode, body);
-				// if the server accepted the events, delete them
-				if (!err && body && body.length) {
-					body.forEach(function (status, i) {
-						// delete the files the server accepted
-						if (status === 204) {
-							let fn = path.join(analyticsDir, files[i]);
-							fs.existsSync(fn) && fs.unlinkSync(fn);
-						}
-					});
-					// pause the event timer if we have no pending events, will
-					// restart automatically when a new event is queued
-					if (timer && fs.readdirSync(analyticsDir).length === 0) {
-						stopSendingEvents();
-					}
-				}
-				callback && callback(err, data, true);
-			});
-		}
+function sendEvent(app_guid, event_name, props, callback, immediate) {
+	// assign at least a logging handler as the finished callback
+	let finished = callback || function defaultCallback(err) {
+		err && debug('sendEvent error', err);
+	};
+
+	// enforce aguid
+	if (!app_guid) {
+		return finished(new Error('missing required guid'));
 	}
-	callback && callback();
-}
 
-/**
- * called to start sending events
- * @private
- */
-function startSendingEvents() {
-	debug('startSendingEvents', flushInterval);
-	if (!timer && flushInterval) {
-		timer = setInterval(flushEvents, flushInterval);
-		// don't allow the process to hold because of the timer if we are ready to exit
-		timer.unref();
-	}
-}
-
-/**
- * called to stop sending events
- * @private
- */
-function stopSendingEvents() {
-	debug('stopSendingEvents');
-	if (timer) {
-		clearInterval(timer);
-		timer = null;
-	}
-}
-
-/**
- * Session class
- * @private
- */
-function Session(guid, mid, sid, deploytype, platform) {
-	this.guid = guid;
-	this.mid = mid;
-	this.sid = sid;
-	this.deploytype = deploytype;
-	this.platform = platform;
-}
-
-/**
- * send a session event
- */
-Session.prototype.send = function (eventdata, event) {
-	sendEvent(this.guid, this.mid, eventdata, event, this.deploytype, this.sid, this.platform);
-};
-
-/**
- * send an end session event
- */
-Session.prototype.end = function (data) {
-	sendEvent(this.guid, this.mid, data, 'ti.end', this.deploytype, this.sid, this.platform);
-};
-
-/**
- * create an analytics Session and send the session start event (ti.start) and then return a session object
- * which `end` should be called when the session is completed.
- */
-function createSession(guid, mid, eventdata, deploytype, platform) {
-	var sid = uuid();
-	sendEvent(guid, mid, eventdata, 'ti.start', deploytype, sid, platform);
-	return new Session(guid, mid, sid, deploytype, platform);
-}
-
-/**
- * send an analytics event to the Analytics API
- */
-function sendEvent(aguid, props, callback, immediate) {
-	if (!aguid) {
-		const err = new Error('missing required guid');
-		if (callback) {
-			return callback(err);
-		}
-		throw err;
+	// enforce event
+	if (!event_name) {
+		return finished(new Error('missing required event name'));
 	}
 
 	// Cast props if not passed as object.
@@ -190,40 +117,283 @@ function sendEvent(aguid, props, callback, immediate) {
 		// get the unique machine id
 		return Appc.Auth.getUniqueMachineID(function (err, machineId) {
 			if (err) {
-				if (callback) {
-					return callback(err);
-				}
-				throw err;
+				return finished(err);
 			}
-			sendEvent(aguid, Object.assign(props, { mid: machineId }), callback, immediate);
+			sendEvent(app_guid, event_name, Object.assign({}, props, { mid: machineId }), callback, immediate);
 		});
 	}
 
+	// base event
 	let event = {
-		id: uuid(),
 		ver: '3',
-		aguid,
-		event: props.event || 'app.feature',
-		sid: props.sid || uuid(),
+		id: uuid(),
 		mid: props.mid,
-		platform: props.platform || Appc.userAgent,
-		deploytype: props.deploytype || 'production',
-		ts: new Date().toISOString(),
+		aguid: app_guid,
+		event: event_name,
 		data: props.data || {},
-		seq: sequence++
+		ts: new Date().toISOString(),
+		deploytype: props.deploytype || 'production'
 	};
 
+	// attach optional fields
+	props.sid && (event.sid = props.sid);
+	props.platform && (event.platform = props.platform);
+
+	// store the event on disk
 	storeEvent(event);
 
-	// immediately send the event if we are immediate or if we have a callback
-	if (immediate || callback) {
-		return flushEvents(callback);
+	// immediately send if needed (if immediate was originally
+	// set to true, or a callback was provided).
+	if (immediate) {
+		return flushEvents(finished);
 	}
 
 	// start sending events (if not already running)
-	startSendingEvents();
-	callback && callback(null, event, false);
+	startFlushTask();
+
+	// pass back payload, false means not immediately sent
+	finished(null, [ event ], false);
 }
+
+/**
+ * Triggers a flush schedule if one is not running.
+ *
+ * This is a timeout rather than an interval to control
+ * the async behaviour of the triggered flush.
+ */
+function startFlushTask() {
+	debug('startFlushTask');
+	!timeout && (timeout = setTimeout(flushEvents, flushInterval));
+}
+
+/**
+ * Cancels a flush schedule if one is running.
+ */
+function stopFlushTask() {
+	debug('stopFlushTask');
+	timeout && clearTimeout(timeout);
+	timeout = undefined;
+}
+
+/**
+ * Stores an event in the internal store, before being
+ * sent by the flush interval.
+ *
+ * @param {object} payload
+ * 		an event payload to send.
+ * @param {function} [callback]
+ * 		an optional callback to fire on completion.
+ * @private
+ */
+function storeEvent(payload, callback) {
+	// assign a default callback in case of missing
+	callback = callback || function defaultCallback(err) {
+		err && debug('storeEvent failure', err);
+	};
+
+	// check the directory exists
+	fs.stat(ANALYTICS_DIR, function (err, stat) {
+		if (err) {
+			// fs error, exit early
+			if (err.code !== 'ENOENT') {
+				return callback(err);
+			}
+
+			// create the missing directory structure
+			return fs.mkdir(ANALYTICS_DIR, function (err) {
+				if (err) {
+					return callback(err);
+				}
+				// add the payload
+				appendPayload(payload, callback);
+			});
+		}
+
+		// has to be a directory
+		if (!stat.isDirectory()) {
+			return callback(new Error('Analytics directory is invalid'));
+		}
+
+		// append the payload if all good
+		appendPayload(payload, callback);
+	});
+}
+
+/**
+ * Appends a payload to the event store on disk.
+ *
+ * @param {object} payload
+ * 		the event payload to store on disk.
+ * @param {function} [callback]
+ * 		an optional callback to fire on completion.
+ * @private
+ */
+function appendPayload(payload, callback) {
+	let file = path.join(ANALYTICS_DIR, Date.now() + '-' + payload.id + '.json');
+	debug('appendPayload', payload, file);
+	fs.writeFile(file, JSON.stringify(payload), function (err) {
+		debug('appendPayload result', err);
+		return err ? callback(err) : callback();
+	});
+}
+
+/**
+ * Flush handler for the internal events.
+ *
+ * This is called (typically) on interval.
+ *
+ * @param {function} [callback]
+ * 		an optional callback to fire on completion.
+ * @private
+ */
+function flushEvents(callback) {
+	// attach a hook to log errors if missing callback
+	function finished(err, data, sent, cancel) {
+		if (!cancel) {
+			startFlushTask();
+		}
+		if (callback) {
+			return callback(err, data, sent);
+		}
+		err && debug('flushEvents failure', err);
+	};
+
+	// read all files in the analytics directory
+	fs.readdir(ANALYTICS_DIR, function (err, files) {
+		if (err) {
+			// return error on fs error
+			debug('flushEvents error', err);
+			if (err.code !== 'ENOENT') {
+				return finished(err);
+			}
+
+			// stop the interval from continuing
+			return finished(null, [], false, true);
+		}
+
+		// no events means we stop polling
+		if (files.length === 0) {
+			return callback(null, [], false, true);
+		}
+
+		async.map(
+			files,
+			function (file, next) {
+				// read in each file and parse it as JSON
+				let joinedPath = path.join(ANALYTICS_DIR, file);
+				fs.readFile(joinedPath, function (err, contents) {
+					if (err) {
+						return next(err);
+					}
+					next(null, JSON.parse(contents));
+				});
+			},
+			function (err, data) {
+				if (err) {
+					return callback(err);
+				}
+
+				// req opts
+				let opts = {
+					url: url,
+					method: 'POST',
+					json: data,
+					timeout: 30000
+				};
+
+				// send the data to the analytics nedpoint
+				debug('flushEvents sending', opts);
+				request(opts, function (err, res) {
+					// debug everything for better logging
+					debug('flushEvents response', err, res.statusCode);
+
+					// pass errors back
+					if (err) {
+						return callback(err);
+					}
+
+					// expect 204, error if not
+					if (res.statusCode !== 204) {
+						return callback(new Error('Bad response from analytics endpoint'));
+					}
+
+					// clean up all files originally read in
+					debug('flushEvents cleanup');
+					async.each(files, fs.unlink, function (err) {
+						err && debug('flushEvents cleanup error', err);
+						return err ? callback(err) : callback(null, opts.data, true);
+					});
+				});
+			}
+		);
+	});
+}
+
+/**
+ * Session class to represent user interaction across time.
+ *
+ * @param {string} guid
+ * 		the guid associated with the session.
+ * @param {string} mid
+ * 		the machine identifier for this device.
+ * @param {string} deploytype
+ * 		the environment this app is deployed in.
+ * @param {string} platform
+ * 		the platform this app is running on.
+ * @constructor
+ */
+function Session(guid, mid, deploytype, platform) {
+	this.guid = guid;
+	this.mid = mid;
+	this.sid = uuid();
+	this.deploytype = deploytype;
+	this.platform = platform;
+}
+
+/**
+ * Sends a session end event.
+ *
+ * @param {object} [data]
+ * 		an optional data payload to send alongside.
+ * @return {Session}
+ * 		the current Session instance.
+ */
+Session.prototype.end = function end(data) {
+	return this.send('ti.end', data);
+};
+
+/**
+ * Sends a session event.
+ *
+ * @param {string} event
+ * 		the event name to send.
+ * @param {object} [data]
+ * 		an optional data payload to send alongside.
+ * @return {Session}
+ * 		the current Session instance.
+ */
+Session.prototype.send = function send(event, data) {
+	sendEvent(this.guid, event, {
+		sid: this.sid,
+		mid: this.mid,
+		platform: this.platform,
+		deploytype: this.deploytype,
+		data
+	});
+	return this;
+};
+
+/**
+ * Sends a session start event.
+ *
+ * @param {object} [data]
+ * 		an optional data payload to send alongside.
+ * @return {Session}
+ * 		the current Session instance.
+ */
+Session.prototype.start = function start(data) {
+	return this.send('ti.start', data);
+};
 
 // on shutdown, try and send any events if possible
 process.once('exit', flushEvents);

--- a/lib/app.js
+++ b/lib/app.js
@@ -100,13 +100,12 @@ function create(session, tiAppPath, orgId, opts, callback) {
 		}
 	}
 
-	if (!fs.existsSync(tiAppPath)) {
-		return callback(new Error('tiapp.xml file does not exist'));
-	}
-
 	fs.readFile(tiAppPath, function (err, tiappxml) {
 		if (err) {
-			return callback(err);
+			if (err.code !== 'ENOENT') {
+				return callback(err);
+			}
+			return callback(new Error('tiapp.xml file does not exist'));
 		}
 		App.save(session, orgId, tiappxml, opts, callback);
 	});

--- a/lib/app.js
+++ b/lib/app.js
@@ -86,6 +86,7 @@ function create(session, tiAppPath, orgId, opts, callback) {
 		orgId = null;
 		opts = {};
 	}
+
 	if (typeof opts === 'function') {
 		callback = opts;
 		opts = {};
@@ -102,10 +103,10 @@ function create(session, tiAppPath, orgId, opts, callback) {
 
 	fs.readFile(tiAppPath, function (err, tiappxml) {
 		if (err) {
-			if (err.code !== 'ENOENT') {
-				return callback(err);
+			if (err.code === 'ENOENT') {
+				return callback(new Error('tiapp.xml file does not exist'));
 			}
-			return callback(new Error('tiapp.xml file does not exist'));
+			return callback(err);
 		}
 		App.save(session, orgId, tiappxml, opts, callback);
 	});

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -8,7 +8,6 @@
  */
 
 const crypto = require('crypto');
-const fs = require('fs');
 const urllib = require('url');
 
 const async = require('async');

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,12 @@ const userAgent = require('./useragent');
 // Init and export, setting module version and user-agent.
 let Appc = exports = module.exports = { version, userAgent };
 
+// Load certificate from environment
+let APPC_CONFIG_CAFILE;
+if (process.env.APPC_CONFIG_CAFILE) {
+	APPC_CONFIG_CAFILE = fs.readFileSync(process.env.APPC_CONFIG_CAFILE);
+}
+
 // Provide env accessor methods and set default env.
 const Env = require('./env');
 Object.assign(Appc, Env);
@@ -123,11 +129,6 @@ function createAPIResponseHandler(callback, mapper, path) {
 			return mapper(body.result || body, callback, resp);
 		}
 		return callback(null, body.result || body, resp);
-		try {
-		}
-		catch(E) {
-			return callback(E, body, resp);
-		}
 	};
 };
 
@@ -180,8 +181,8 @@ Appc.createRequestOpts = function (session, url, authToken) {
 		opts.proxy = process.env.APPC_CONFIG_PROXY;
 	}
 
-	if (process.env.APPC_CONFIG_CAFILE) {
-		opts.ca = fs.readFileSync(process.env.APPC_CONFIG_CAFILE);
+	if (APPC_CONFIG_CAFILE) {
+		opts.ca = APPC_CONFIG_CAFILE;
 	}
 
 	if (process.env.APPC_CONFIG_STRICTSSL === 'false') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,25 +110,30 @@ function createAPIResponseHandler(callback, mapper, path) {
 		}
 		let ct = resp.headers['content-type'],
 			isJSON = ct && ct.indexOf('/json') > 0;
-		body = typeof body === 'object' ? body : isJSON && JSON.parse(body) || body;
-		if (!body.success) {
-			debug('api body failed, was: %o', body);
-			let description = typeof body.description === 'object' ? body.description.message : body.description || 'unexpected response from the server';
-			let error = new Error(description);
-			error.success = false;
-			error.description = description;
-			error.code = body.code;
-			error.internalCode = body.internalCode;
-			typeof body === 'string' && (error.content = body);
-			return callback(error);
+		try {
+			body = typeof body === 'object' ? body : isJSON && JSON.parse(body) || body;
+			if (!body.success) {
+				debug('api body failed, was: %o', body);
+				let description = typeof body.description === 'object' ? body.description.message : body.description || 'unexpected response from the server';
+				let error = new Error(description);
+				error.success = false;
+				error.description = description;
+				error.code = body.code;
+				error.internalCode = body.internalCode;
+				typeof body === 'string' && (error.content = body);
+				return callback(error);
+			}
+			if (!body.result && body.key) {
+				body.result = body[body.key];
+			}
+			if (mapper) {
+				return mapper(body.result || body, callback, resp);
+			}
+			return callback(null, body.result || body, resp);
 		}
-		if (!body.result && body.key) {
-			body.result = body[body.key];
+		catch(E) {
+			return callback(E, body, resp);
 		}
-		if (mapper) {
-			return mapper(body.result || body, callback, resp);
-		}
-		return callback(null, body.result || body, resp);
 	};
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -48,7 +48,7 @@ describe('Appc.Analytics', function () {
 	});
 
 	afterEach(function () {
-		Appc.Analytics.stopFlushTask();
+		Appc.Analytics.stopFlush();
 		Appc.Analytics.url = 'http://127.0.0.1:' + app.get('port') + '/track';
 		notifier = null;
 		fs.existsSync(Appc.Analytics.analyticsDir) && wrench.rmdirSyncRecursive(Appc.Analytics.analyticsDir);

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -48,24 +48,22 @@ describe('Appc.Analytics', function () {
 	});
 
 	afterEach(function () {
-		Appc.Analytics.stopSendingEvents();
+		Appc.Analytics.stopFlushTask();
 		Appc.Analytics.url = 'http://127.0.0.1:' + app.get('port') + '/track';
 		notifier = null;
 		fs.existsSync(Appc.Analytics.analyticsDir) && wrench.rmdirSyncRecursive(Appc.Analytics.analyticsDir);
 	});
 
-	it('should send analytics data with guid only', function (done) {
+	it('should send analytics data with guid and event only', function (done) {
 		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.sendEvent('guid', null, function (err, result, sent) {
+		Appc.Analytics.sendEvent('guid', 'app.feature', null, function (err, result, sent) {
 			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(sent).be.true;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
-			should(result[0]).have.property('sid');
 			should(result[0]).have.property('mid');
 			should(result[0]).have.property('aguid', 'guid');
-			should(result[0]).have.property('platform', Appc.userAgent);
 			should(result[0]).have.property('deploytype', 'production');
 			should(result[0]).have.property('ts');
 			should(result[0]).have.property('event', 'app.feature');
@@ -73,23 +71,20 @@ describe('Appc.Analytics', function () {
 			should(result[0]).have.property('ver', '3');
 			should(Date.parse(result[0].ts)).be.a.Date;
 			should(result[0].id).match(/^[\w-]{16,}$/);
-			should(result[0].sid).match(/^[\w-]{16,}$/);
 			should(result[0].data).be.eql({});
 			done();
 		});
 	});
 
-	it('should send analytics data with guid and mid only', function (done) {
+	it('should send analytics data with guid, event and mid', function (done) {
 		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.sendEvent('guid', { mid: 'mid' }, function (err, result) {
+		Appc.Analytics.sendEvent('guid', 'app.feature', { mid: 'mid' }, function (err, result) {
 			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
-			should(result[0]).have.property('sid');
 			should(result[0]).have.property('mid', 'mid');
 			should(result[0]).have.property('aguid', 'guid');
-			should(result[0]).have.property('platform', Appc.userAgent);
 			should(result[0]).have.property('deploytype', 'production');
 			should(result[0]).have.property('ts');
 			should(result[0]).have.property('event', 'app.feature');
@@ -97,23 +92,20 @@ describe('Appc.Analytics', function () {
 			should(result[0]).have.property('ver', '3');
 			should(Date.parse(result[0].ts)).be.a.Date;
 			should(result[0].id).match(/^[\w-]{16,}$/);
-			should(result[0].sid).match(/^[\w-]{16,}$/);
 			should(result[0].data).be.eql({});
 			done();
 		});
 	});
 
-	it('should send analytics data with guid, mid, eventdata', function (done) {
+	it('should send analytics data with guid, mid, event, data', function (done) {
 		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.sendEvent('guid', { mid: 'mid', data: { a: 1 } }, function (err, result) {
+		Appc.Analytics.sendEvent('guid', 'app.feature', { mid: 'mid', data: { a: 1 } }, function (err, result) {
 			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
-			should(result[0]).have.property('sid');
 			should(result[0]).have.property('mid', 'mid');
 			should(result[0]).have.property('aguid', 'guid');
-			should(result[0]).have.property('platform', Appc.userAgent);
 			should(result[0]).have.property('deploytype', 'production');
 			should(result[0]).have.property('ts');
 			should(result[0]).have.property('event', 'app.feature');
@@ -121,47 +113,20 @@ describe('Appc.Analytics', function () {
 			should(result[0]).have.property('ver', '3');
 			should(Date.parse(result[0].ts)).be.a.Date;
 			should(result[0].id).match(/^[\w-]{16,}$/);
-			should(result[0].sid).match(/^[\w-]{16,}$/);
 			should(result[0].data).be.eql({ a:1 });
 			done();
 		});
 	});
 
-	it('should send analytics data with guid, mid, eventdata, event', function (done) {
+	it('should send analytics data with guid, mid, data, event, deploytype', function (done) {
 		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.sendEvent('guid', { event: 'event', mid: 'mid', data: { a: 1 } }, function (err, result) {
+		Appc.Analytics.sendEvent('guid', 'event', { mid: 'mid', deploytype: 'deploytype', data: { a: 1 } }, function (err, result) {
 			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
-			should(result[0]).have.property('sid');
 			should(result[0]).have.property('mid', 'mid');
 			should(result[0]).have.property('aguid', 'guid');
-			should(result[0]).have.property('platform', Appc.userAgent);
-			should(result[0]).have.property('deploytype', 'production');
-			should(result[0]).have.property('ts');
-			should(result[0]).have.property('event', 'event');
-			should(result[0]).have.property('data');
-			should(result[0]).have.property('ver', '3');
-			should(Date.parse(result[0].ts)).be.a.Date;
-			should(result[0].id).match(/^[\w-]{16,}$/);
-			should(result[0].sid).match(/^[\w-]{16,}$/);
-			should(result[0].data).be.eql({ a:1 });
-			done();
-		});
-	});
-
-	it('should send analytics data with guid, mid, eventdata, event, deploytype', function (done) {
-		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.sendEvent('guid', { event: 'event', mid: 'mid', deploytype: 'deploytype', data: { a: 1 } }, function (err, result) {
-			should(err).not.be.ok();
-			should(result).be.an.array;
-			should(result).have.length(1);
-			should(result[0]).have.property('id');
-			should(result[0]).have.property('sid');
-			should(result[0]).have.property('mid', 'mid');
-			should(result[0]).have.property('aguid', 'guid');
-			should(result[0]).have.property('platform', Appc.userAgent);
 			should(result[0]).have.property('deploytype', 'deploytype');
 			should(result[0]).have.property('ts');
 			should(result[0]).have.property('event', 'event');
@@ -169,15 +134,14 @@ describe('Appc.Analytics', function () {
 			should(result[0]).have.property('ver', '3');
 			should(Date.parse(result[0].ts)).be.a.Date;
 			should(result[0].id).match(/^[\w-]{16,}$/);
-			should(result[0].sid).match(/^[\w-]{16,}$/);
 			should(result[0].data).be.eql({ a:1 });
 			done();
 		});
 	});
 
-	it('should send analytics data with guid, mid, eventdata, event, deploytype and sid', function (done) {
+	it('should send analytics data with guid, mid, data, event, deploytype and sid', function (done) {
 		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.sendEvent('guid', { event: 'event', mid: 'mid', deploytype: 'deploytype', sid: 'sid-sid-sid-sid-sid-sid', data: { a: 1 } }, function (err, result) {
+		Appc.Analytics.sendEvent('guid', 'event', { mid: 'mid', deploytype: 'deploytype', sid: 'sid-sid-sid-sid-sid-sid', data: { a: 1 } }, function (err, result) {
 			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
@@ -185,7 +149,6 @@ describe('Appc.Analytics', function () {
 			should(result[0]).have.property('sid', 'sid-sid-sid-sid-sid-sid');
 			should(result[0]).have.property('mid', 'mid');
 			should(result[0]).have.property('aguid', 'guid');
-			should(result[0]).have.property('platform', Appc.userAgent);
 			should(result[0]).have.property('deploytype', 'deploytype');
 			should(result[0]).have.property('ts');
 			should(result[0]).have.property('event', 'event');
@@ -193,7 +156,6 @@ describe('Appc.Analytics', function () {
 			should(result[0]).have.property('ver', '3');
 			should(Date.parse(result[0].ts)).be.a.Date;
 			should(result[0].id).match(/^[\w-]{16,}$/);
-			should(result[0].sid).match(/^[\w-]{16,}$/);
 			should(result[0].data).be.eql({ a:1 });
 			done();
 		});
@@ -231,15 +193,13 @@ describe('Appc.Analytics', function () {
 	it('should send analytics to real url and get back result', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.url = originalUrl;
-		Appc.Analytics.sendEvent(global.$config.apps.enterprise.app_guid, {}, function (err, result, sent) {
+		Appc.Analytics.sendEvent(global.$config.apps.enterprise.app_guid, 'app.feature', {}, function (err, result, sent) {
 			should(err).not.be.ok();
 			should(result).be.an.array;
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
-			should(result[0]).have.property('sid');
 			should(result[0]).have.property('mid');
 			should(result[0]).have.property('aguid', global.$config.apps.enterprise.app_guid);
-			should(result[0]).have.property('platform', Appc.userAgent);
 			should(result[0]).have.property('deploytype', 'production');
 			should(result[0]).have.property('ts');
 			should(result[0]).have.property('event', 'app.feature');
@@ -247,7 +207,6 @@ describe('Appc.Analytics', function () {
 			should(result[0]).have.property('ver', '3');
 			should(Date.parse(result[0].ts)).be.a.Date;
 			should(result[0].id).match(/^[\w-]{16,}$/);
-			should(result[0].sid).match(/^[\w-]{16,}$/);
 			should(sent).be.true;
 			done();
 		});


### PR DESCRIPTION
This PR strips out a bunch of synchronous functions, because they're a horrible thing to have in a third-party library. It also fixes a bunch of bugs related to the event flushing in `Appc.Analytics`. 

The interval now operates as a timeout in order to allow for the new asynchronous behaviour (otherwise it would just keep firing all the time). Previously if you set the interval to `0`, it would just block up an application (noticeably). 

Bunch of other refactoring, event is now required, bunch of defaults removed, that kinda stuff. All makes sense.

