### PR TITLE
[APPTS-9652] Update env urls to axway domains

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,54 +1,38 @@
-var sdk = require('./'),
-	path = require('path'),
-	args = process.argv.slice(2);
+const path = require('path');
+const args = process.argv.slice(2);
 
+const Appc = require('.');
 
-if (args.length!==2) {
-	console.error('Usage: node '+path.basename(module.filename)+' <username> <password>');
+if (args.length !== 2) {
+	console.error('Usage: node ' + path.basename(module.filename) + ' <username> <password>');
 	process.exit(1);
-}
-
-function Decycler() {
-	var cache = [];
-	return function(key, value) {
-	    if (typeof value === 'object' && value !== null) {
-	        if (cache.indexOf(value) !== -1) {
-	            // Circular reference found, discard key
-	            return;
-	        }
-	        // Store value in our collection
-	        cache.push(value);
-	    }
-	    return value;
-	};
 }
 
 function die() {
-	console.error.apply(console.err,arguments);
+	console.error.apply(console, arguments);
 	process.exit(1);
 }
 
-sdk.setDevelopment();
+Appc.Env.setDevelopment();
 
-sdk.Auth.login(args[0], args[1], function(err,session){
-	if (err) { die('Error=',err); }
-	console.log(JSON.stringify(session,Decycler(),2));
+Appc.Auth.login(args[0], args[1], function (err, session) {
+	err && die('Error', err);
 
-	/*
-	sdk.App.create(session, '/Users/jhaynie/tmp/foo/app/tiapp.xml', function(err,result){
-		console.log(arguments);
-	});*/
+	console.log(JSON.stringify(session, null, 2));
 
-	/*try {
-		sdk.Auth.createSessionFromID(session.id, function(err,session_){
-			if (err) { die('Error=',err); }
-			sdk.App.findAll(session_, function(err, apps){
-				if (err) { die('Error=',err); }
+	Appc.App.create(session, path.join(process.env.PWD, 'test', 'titestapp1', 'tiapp.xml'), console.log);
+
+	try {
+		Appc.Auth.createSessionFromID(session.id, function (err, session_) {
+			err && die('Error', err);
+
+			Appc.App.findAll(session_, function (err, apps) {
+				err && die('Error', err);
+
 				console.log(apps);
 			});
 		});
+	} catch (e) {
+		console.error(e.stack);
 	}
-	catch (E) {
-		console.error(E.stack);
-	}*/
 });

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -7,7 +7,6 @@
  * license restrictions and information about usage and distribution.
  */
 
-const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -67,7 +66,7 @@ let timeout;
  *		the platform this session is running on.
  * @param {object} data
  * 		arbitrary data to store alongside the session.
- * @returns
+ * @returns {object}
  * 		a new Session instance.
  */
 function createSession(app_guid, mid, deploytype, platform, data) {
@@ -254,7 +253,7 @@ function flushEvents(callback) {
 			return callback(err, data, sent);
 		}
 		err && debug('flushEvents failure', err);
-	};
+	}
 
 	// read all files in the analytics directory
 	fs.readdir(ANALYTICS_DIR, function (err, files) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -43,7 +43,7 @@ function findAll(session, orgId, callback) {
 		orgId = null;
 	}
 	Appc.createRequest(session, '/api/v1/app' + (orgId ? ('?org_id=' + orgId) : ''), callback);
-};
+}
 
 /**
  * find a specific app by id
@@ -54,7 +54,7 @@ function findAll(session, orgId, callback) {
  */
 function find(session, appId, callback) {
 	Appc.createRequest(session, '/api/v1/app/' + appId, callback);
-};
+}
 
 /**
  * update an app
@@ -69,7 +69,7 @@ function update(session, app, callback) {
 		return callback(new Error('no app_guid property found'));
 	}
 	Appc.createRequest(session, '/api/v1/app/' + guid, 'put', callback, app);
-};
+}
 
 /**
  * Create or update an app from tiapp.xml file.
@@ -110,7 +110,7 @@ function create(session, tiAppPath, orgId, opts, callback) {
 		}
 		App.save(session, orgId, tiappxml, opts, callback);
 	});
-};
+}
 
 /**
  * Create or update an app from tiapp.xml file.
@@ -141,7 +141,7 @@ function save(session, orgId, tiappxml, opts, callback) {
 		form.append('tiapp', tiappxml, { filename: 'tiapp.xml' });
 		debug('form parameters for %s, %o', req.uri.href, form);
 	}
-};
+}
 
 /**
  * find an application package by application guid; can be called with token or session
@@ -161,14 +161,14 @@ function findPackage(session, guid, token, callback) {
 		callback = token;
 	}
 	Appc.createRequest(session || token, '/api/v1/app/' + guid + '/package', callback);
-};
+}
 
 /**
  * for a given application guid, find the configuration application teams
  */
 function findTeamMembers(session, guid, callback) {
 	Appc.createRequest(session, '/api/v1/app/' + guid + '/team', callback);
-};
+}
 
 /**
  * delete a specific app by id
@@ -178,7 +178,7 @@ function findTeamMembers(session, guid, callback) {
  */
 function deleteApp(session, appId, callback) {
 	Appc.createRequest(session, '/api/v1/app/' + appId, 'del', callback);
-};
+}
 
 /**
  * Fetch Apteligent ID for app.
@@ -188,4 +188,4 @@ function deleteApp(session, appId, callback) {
  */
 function crittercismID(session, guid, callback) {
 	Appc.createRequest(session, '/api/v1/app/' + guid + '/crittercism_id', callback);
-};
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -72,7 +72,7 @@ function getUniqueMachineID(callback) {
 		cachedMac = macAddress;
 		return callback(null, cachedMac);
 	});
-};
+}
 
 /**
  * login
@@ -143,7 +143,7 @@ function login(params, callback) {
 		form.append(field, fields[field]);
 	});
 	debug('form parameters for %s, %o', r.url, Object.assign({}, fields, { password: '[REDACTED]' }));
-};
+}
 
 /**
  * logout. once this method completes the session will no longer be valid
@@ -153,7 +153,7 @@ function logout(session, callback) {
 		session._invalidate();
 		callback && callback(e);
 	});
-};
+}
 
 /**
  * switch the user's logged in user
@@ -212,7 +212,7 @@ function switchLoggedInOrg(session, orgId, callback) {
 			debug('form parameters for %s, %o', req.url, form);
 		}
 	});
-};
+}
 
 /**
  * from a current logged in authenticated request, return a new Session object
@@ -227,7 +227,7 @@ function createSessionFromRequest(req, callback) {
 		return callback(_makeError('not logged in', ERROR_NOT_AUTHORIZED));
 	}
 	return createSessionFromID(id, callback);
-};
+}
 
 /**
  * from an existing authenticated session, create a new Session object
@@ -300,7 +300,7 @@ function createSessionFromID(id, callback) {
 			});
 		});
 	});
-};
+}
 
 /**
  * request a login code
@@ -332,7 +332,7 @@ function requestLoginCode(session, sms, callback) {
 			form.append('sendto', sms ? user.phone : user.email);
 		}
 	});
-};
+}
 
 /**
  * validate a session with platform, returns basic user identity if success or
@@ -366,7 +366,7 @@ function validateSession(obj, callback) {
 	});
 
 	request(opts, Appc.createAPIResponseHandler(callback));
-};
+}
 
 /**
  * given a user code, check for validation of this code
@@ -392,7 +392,7 @@ function verifyLoginCode(session, code, callback) {
 		let form = r.form();
 		form.append('code', code);
 	}
-};
+}
 
 /**
  * invalidate any cached sessions
@@ -401,7 +401,7 @@ function invalidCachedSession() {
 	debug('invalidCachedSession');
 	cachedSessionKey = null;
 	cachedSession = null;
-};
+}
 
 /**
  * cause a new session to be cached
@@ -411,7 +411,7 @@ function cacheSession(session) {
 		cachedSessionKey = session.id;
 		cachedSession = session;
 	}
-};
+}
 
 /**
  * Make an error object

--- a/lib/cloud.js
+++ b/lib/cloud.js
@@ -67,15 +67,13 @@ function createCloudResponseHandler(callback) {
 		if (response && response.statusCode !== 200) {
 			try {
 				body = JSON.parse(body);
-			}
-			catch(e) {}
+			} catch (e) {}
 			return callback(body.meta && body.meta.message || 'Server error');
 		}
 		if (body) {
 			try {
 				body = JSON.parse(body);
-			}
-			catch(e) {
+			} catch (e) {
 				return callback(e);
 			}
 			if (body.meta && body.meta.status === 'ok') {
@@ -99,7 +97,7 @@ function login(session, callback) {
 			}
 			return callback(err, body);
 		}));
-	} catch(e) {
+	} catch (e) {
 		return callback(e);
 	}
 }
@@ -176,10 +174,10 @@ function createNamedApp(session, name, callback) {
 				return callback(err);
 			}
 		});
-	} catch(e) {
+	} catch (e) {
 		return callback(e);
 	}
-};
+}
 
 /**
  * create a new cloud app for a given application (returns an array of apps, one for each environment)
@@ -208,7 +206,7 @@ function createApp(session, appName, orgId, appGuid, callback) {
 		}
 		debug('form parameters for %s, %o', req.url, form);
 	}
-};
+}
 
 /**
  * create an ACS cloud user
@@ -227,7 +225,7 @@ function createUser(session, guid, keyvalues, callback) {
 		});
 		debug('form parameters for %s, %o', req.url, form);
 	}
-};
+}
 
 /**
  * return the appropriate environment url.
@@ -248,7 +246,7 @@ function getEnvironment(session, type, name) {
 	return session.user.org.envs.find(function (env) {
 		return env.name === name;
 	})[type];
-};
+}
 
 /**
  * retrieve the list of ACS users for the app guid
@@ -259,4 +257,4 @@ function getEnvironment(session, type, name) {
  */
 function retrieveUsers(session, guid, callback) {
 	Appc.createRequest(session, '/api/v1/acs/' + guid + '/data.next/user', createACSResponseHandler('users', callback));
-};
+}

--- a/lib/env.js
+++ b/lib/env.js
@@ -4,21 +4,17 @@ const debug = require('debug')('Appc:sdk:env');
 
 const envs = {
 	Production: {
-		baseurl: 'https://platform.appcelerator.com',
-		registryurl: 'https://software.appcelerator.com',
-		pubsuburl: 'https://pubsub.appcelerator.com',
-		webeventurl: 'https://webevent.appcelerator.com',
-		cacheurl: 'https://cache.appcelerator.com',
+		baseurl: 'https://platform.axway.com',
+		registryurl: 'https://registry.axway.com',
+		pubsuburl: 'https://notifications.axway.com',
 		isProduction: true,
 		supportUntrusted: false,
 		secureCookies: true
 	},
 	Preproduction: {
-		baseurl: 'https://360-preprod.cloud.appctest.com',
-		registryurl: 'https://software-preprod.cloud.appctest.com',
-		pubsuburl: 'https://pubsub-preprod.cloud.appctest.com',
-		webeventurl: 'https://webevent-preprod.cloud.appctest.com',
-		cacheurl: 'https://cache-preprod.cloud.appctest.com',
+		baseurl: 'https://platform-preprod.axwaytest.net',
+		registryurl: 'https://registry.axwaytest.net',
+		pubsuburl: 'https://notifications.axwaytest.net',
 		isProduction: false,
 		supportUntrusted: true,
 		secureCookies: true
@@ -27,18 +23,6 @@ const envs = {
 		baseurl: 'https://platform-eu.appcelerator.com',
 		registryurl: 'https://software-eu.appcelerator.com',
 		pubsuburl: 'https://pubsub.appcelerator.com',
-		webeventurl: 'https://webevent.appcelerator.com',
-		cacheurl: 'https://cache.appcelerator.com',
-		isProduction: true,
-		supportUntrusted: false,
-		secureCookies: true
-	},
-	PlatformAxway: {
-		baseurl: 'https://portal.cloudapp.axway.com',
-		registryurl: 'https://marketplace.cloudapp.axway.com',
-		pubsuburl: 'https://pubsub.appcelerator.com',
-		webeventurl: 'https://webevent.appcelerator.com',
-		cacheurl: 'https://cache.appcelerator.com',
 		isProduction: true,
 		supportUntrusted: false,
 		secureCookies: true
@@ -49,8 +33,6 @@ const platformMap = {
 	baseurl: 'APPC_DASHBOARD_URL',
 	registryurl: 'APPC_REGISTRY_SERVER',
 	pubsuburl: 'APPC_PUBSUB_URL',
-	webeventurl: 'APPC_WEBEVENT_URL',
-	cacheurl: 'APPC_CACHE_URL',
 	supportUntrusted: 'APPC_SUPPORT_UNTRUSTED',
 	secureCookies: 'APPC_SECURE_COOKIES'
 };
@@ -80,7 +62,7 @@ Env.setDevelopment = Env.setPreproduction;
 /**
  * set the base url to use local development
  */
-Env.setLocal = function setLocal(opts) {
+Env.setLocal = function setLocal() {
 	Env.setPreproduction();
 	Env.baseurl = 'http://localhost:9009';
 	Env.secureCookies = false;
@@ -90,6 +72,8 @@ Env.setLocal = function setLocal(opts) {
 
 /**
  * set a custom environment, use local config as defaults
+ *
+ * @param {object} opts options
  */
 Env.setEnvironment = function setEnvironment(opts) {
 	opts = opts || {};
@@ -98,8 +82,6 @@ Env.setEnvironment = function setEnvironment(opts) {
 	Env.baseurl = (opts.baseurl || base.baseurl).trim();
 	Env.registryurl = (opts.registry || base.registryurl).trim();
 	Env.pubsuburl = (opts.pubsub || base.pubsuburl).trim();
-	Env.webeventurl = (opts.webevent || base.webeventurl).trim();
-	Env.cacheurl = (opts.cache || base.cacheurl).trim();
 	Env.isProduction = typeof opts.isProduction !== 'undefined' ? opts.isProduction : base.isProduction;
 	Env.supportUntrusted = typeof opts.supportUntrusted !== 'undefined' ? opts.supportUntrusted : base.supportUntrusted;
 	Env.secureCookies = typeof opts.secureCookies !== 'undefined' ? opts.secureCookies : base.secureCookies;
@@ -117,7 +99,9 @@ function _isPreproduction() {
 
 /**
  * Test NODE_ENV and APPC_ENV values to see if they match env name(s).
- * @return {boolean} - true if yes
+ *
+ * @param {array|any} envs array of environments objects
+ * @return {boolean} true if yes
  */
 function _isEnv(envs) {
 	if (!Array.isArray(envs)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,12 +132,11 @@ function createAPIResponseHandler(callback, mapper, path) {
 				return mapper(body.result || body, callback, resp);
 			}
 			return callback(null, body.result || body, resp);
-		}
-		catch(E) {
+		} catch (E) {
 			return callback(E, body, resp);
 		}
 	};
-};
+}
 
 /**
  * Create a request to the platform and return the request object. this time with a custom handler
@@ -237,7 +236,7 @@ function _createRequest(session, path, method, responseHandler, json) {
 		}
 
 		return request[method.toLowerCase()](opts, responseHandler);
-	} catch(e) {
+	} catch (e) {
 		// don't return the callback since it expects a request object
 		responseHandler(e);
 	}

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -141,7 +141,7 @@ function createUserFromSession(session) {
 	};
 
 	return user;
-};
+}
 
 /**
  * handle unauthorized

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -16,6 +16,9 @@ let Notification = exports = module.exports = {};
 
 /**
  * find all the notifications for the logged in user
+ *
+ * @param {object} session session object
+ * @param {function} callback callback
  */
 Notification.findAll = function findAll(session, callback) {
 	Appc.createRequest(session, '/api/v1/notification', callback);

--- a/lib/org.js
+++ b/lib/org.js
@@ -49,7 +49,7 @@ function find(session, callback) {
 		cachedOrgKey = session.id;
 		return callback(null, org, resp);
 	});
-};
+}
 
 /**
  * Return an organization by checking the session
@@ -70,7 +70,7 @@ function getById(session, id, callback) {
 	}
 
 	return callback(new Error('id is not valid'));
-};
+}
 
 /**
  * Find organization for a given org id
@@ -85,7 +85,7 @@ function findById(session, id, callback) {
 	}
 
 	Appc.createRequest(session, '/api/v1/org/' + id, callback);
-};
+}
 
 /**
  * Get an organization by name
@@ -106,7 +106,7 @@ function getByName(session, name, callback) {
 	}
 
 	return callback(new Error('Org not found'));
-};
+}
 
 /**
  * Return the current logged in organization
@@ -120,4 +120,4 @@ function getCurrent(session, callback) {
 	}
 
 	return callback(new Error('session is not valid'));
-};
+}

--- a/lib/user.js
+++ b/lib/user.js
@@ -58,4 +58,4 @@ function find(session, userId, callback) {
 
 		return callback(null, user);
 	});
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "2.4.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -56,6 +56,7 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
       "requires": {
         "co": "4.6.0",
         "json-stable-stringify": "1.0.1"
@@ -129,7 +130,8 @@
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
     },
     "ast-types": {
       "version": "0.9.12",
@@ -139,7 +141,7 @@
     "async": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -152,7 +154,8 @@
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
     },
     "aws4": {
       "version": "1.6.0",
@@ -247,14 +250,14 @@
       }
     },
     "body-parser": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.1.tgz",
-      "integrity": "sha512-KL2pZpGvy6xuZHgYUznB1Zfw4AoGMApfRanT5NafeLvglbaSM+4CCtmlyYOv66oYXqvKL1xpaFb94V/AZVUnYg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
@@ -264,6 +267,15 @@
         "type-is": "1.6.15"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -276,6 +288,7 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -476,14 +489,25 @@
       "dev": true
     },
     "cookie-session": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.3.1.tgz",
-      "integrity": "sha1-zkHLFUe01E2c888ySHg2BWjOrAM=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.3.2.tgz",
+      "integrity": "sha1-Rp26djCMAQtSnpp8+dh7ZJvgGQs=",
       "dev": true,
       "requires": {
         "cookies": "0.7.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "cookie-signature": {
@@ -522,6 +546,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -550,12 +575,12 @@
     "data-uri-to-buffer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -708,7 +733,7 @@
     "es6-promise": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+      "integrity": "sha1-iBHpCRXZoNujYnTwskLb2nj5ySo="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -753,7 +778,6 @@
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.8",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
         "espree": "3.5.0",
@@ -823,7 +847,6 @@
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
         "resolve": "1.4.0"
       }
     },
@@ -833,7 +856,6 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
         "pkg-dir": "1.0.0"
       }
     },
@@ -845,7 +867,6 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.8",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.1",
         "eslint-module-utils": "2.1.1",
@@ -952,9 +973,9 @@
       "dev": true
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
+      "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
@@ -963,13 +984,13 @@
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.4",
-        "fresh": "0.5.0",
+        "finalhandler": "1.0.6",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
@@ -978,8 +999,8 @@
         "proxy-addr": "1.1.5",
         "qs": "6.5.0",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
+        "send": "0.15.6",
+        "serve-static": "1.12.6",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
@@ -987,11 +1008,74 @@
         "vary": "1.1.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "finalhandler": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+          "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true
+        },
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
           "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
           "dev": true
+        },
+        "send": {
+          "version": "0.15.6",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
+          "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.2",
+            "mime": "1.3.4",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.12.6",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
+          "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
+          "dev": true,
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
+            "send": "0.15.6"
+          }
         }
       }
     },
@@ -1035,8 +1119,7 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1065,22 +1148,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
-    "finalhandler": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      }
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
     },
     "find-up": {
       "version": "1.1.2",
@@ -1109,26 +1177,10 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
-    },
     "forwarded": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.1.tgz",
       "integrity": "sha1-ik4wxkCwU5U5mjVJxzAldygEiWE=",
-      "dev": true
-    },
-    "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
     },
     "fs.realpath": {
@@ -1189,14 +1241,24 @@
     "get-uri": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.1.tgz",
-      "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
+      "integrity": "sha1-29ysrNjGCKODFoaTaBF2l6FjHFk=",
       "requires": {
         "data-uri-to-buffer": "1.2.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "extend": "3.0.1",
         "file-uri-to-path": "1.0.0",
         "ftp": "0.3.10",
         "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "getmac": {
@@ -1225,7 +1287,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1292,20 +1354,6 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
-    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -1334,6 +1382,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
@@ -1350,7 +1399,8 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -1375,14 +1425,25 @@
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "extend": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
       "requires": {
         "assert-plus": "0.2.0",
         "jsprim": "1.4.1",
@@ -1395,8 +1456,18 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "extend": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "i": {
@@ -1619,8 +1690,7 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1913,7 +1983,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -1937,7 +2007,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1954,6 +2024,15 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
@@ -1988,7 +2067,7 @@
     "mocha-jenkins-reporter": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.3.9.tgz",
-      "integrity": "sha512-+/nhhGRiAVkoQcapiWdlazL/6/bDr+adQYHQ3sjKR3ipB7O2cZIuGvkgaeKDxMtEFby/ZbWhi2CYHhtJm487GA==",
+      "integrity": "sha1-ovOr1SrJqqMmzwf2diGE3Zn6ziQ=",
       "dev": true,
       "requires": {
         "diff": "1.0.7",
@@ -3773,22 +3852,32 @@
     "pac-proxy-agent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.0.tgz",
-      "integrity": "sha512-t57UiJpi5mFLTvjheC1SNSwIhml3+ElNOj69iRrydtQXZJr8VIFYSDtyPi/3ZysA62kD2dmww6pDlzk0VaONZg==",
+      "integrity": "sha1-vrF80rBqILN51X4bLiwpvg3+X5o=",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "get-uri": "2.0.1",
         "http-proxy-agent": "1.0.0",
         "https-proxy-agent": "1.0.0",
         "pac-resolver": "3.0.0",
         "raw-body": "2.3.2",
         "socks-proxy-agent": "3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "pac-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
       "requires": {
         "co": "4.6.0",
         "degenerator": "1.0.4",
@@ -3853,11 +3942,6 @@
       "requires": {
         "pify": "2.3.0"
       }
-    },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
       "version": "2.3.0",
@@ -3958,11 +4042,6 @@
       "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U=",
       "dev": true
     },
-    "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-    },
     "ramda": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
@@ -4030,7 +4109,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4049,7 +4128,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -4057,32 +4136,149 @@
       }
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.6.0",
+        "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.5",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "5.2.3",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.0.2"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "sntp": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+          "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "require-uncached": {
@@ -4168,7 +4364,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -4189,39 +4385,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
       "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-    },
-    "send": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "fresh": "0.5.0",
-        "http-errors": "1.6.2",
-        "mime": "1.3.4",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      }
-    },
-    "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
-      "dev": true,
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
-        "send": "0.15.4"
-      }
     },
     "setprototypeof": {
       "version": "1.0.3",
@@ -4318,6 +4481,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -4334,7 +4498,7 @@
     "socks-proxy-agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
-      "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
+      "integrity": "sha1-6iMIXNK96U0ISmJEjzETnKftYkU=",
       "requires": {
         "agent-base": "4.1.1",
         "socks": "1.1.10"
@@ -4343,7 +4507,7 @@
         "agent-base": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
-          "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
+          "integrity": "sha1-ktik/CUko7CbNmajO2yXlg8j1qQ=",
           "requires": {
             "es6-promisify": "5.0.0"
           }
@@ -4416,6 +4580,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4431,11 +4600,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
       "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns=",
       "dev": true
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -4542,9 +4706,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -4663,7 +4827,7 @@
             "oauth-sign": "0.8.2",
             "qs": "6.2.3",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3"
           }
         },
@@ -4772,7 +4936,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,25 +53,26 @@
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
       "requires": {
         "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
         "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
       "dev": true
     },
     "ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -128,20 +129,19 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "ast-types": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.12.tgz",
-      "integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k="
+      "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.13.tgz",
+      "integrity": "sha512-72w1vrspLfSP4htDZWMgDya3gz7VFIojiaxWdXfJkpR/KouBvJZ2xoHxG79VwdGr8ZdG/b6zgwqoIG24QtRqCQ=="
     },
     "async": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -152,10 +152,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.6.0",
@@ -275,22 +274,15 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
         }
       }
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "brace-expansion": {
@@ -543,12 +535,21 @@
       }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "cycle": {
@@ -563,19 +564,12 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "data-uri-to-buffer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU="
+      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
     },
     "debug": {
       "version": "3.1.0",
@@ -601,7 +595,7 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "requires": {
-        "ast-types": "0.9.12",
+        "ast-types": "0.9.13",
         "escodegen": "1.9.0",
         "esprima": "3.1.3"
       }
@@ -733,7 +727,7 @@
     "es6-promise": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha1-iBHpCRXZoNujYnTwskLb2nj5ySo="
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -768,19 +762,20 @@
       }
     },
     "eslint": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
-      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
+      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
+        "ajv": "5.2.3",
         "babel-code-frame": "6.26.0",
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.0",
+        "espree": "3.5.1",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -790,7 +785,7 @@
         "globals": "9.18.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.3",
+        "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
@@ -801,28 +796,16 @@
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
+        "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.1",
+        "table": "4.0.2",
         "text-table": "0.2.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -847,7 +830,19 @@
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "dev": true,
       "requires": {
+        "debug": "2.6.9",
         "resolve": "1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -856,7 +851,19 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
+        "debug": "2.6.9",
         "pkg-dir": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -867,6 +874,7 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.1",
         "eslint-module-utils": "2.1.1",
@@ -876,6 +884,15 @@
         "read-pkg-up": "2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -923,9 +940,9 @@
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
         "acorn": "5.1.2",
@@ -1005,7 +1022,7 @@
         "statuses": "1.3.1",
         "type-is": "1.6.15",
         "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -1017,65 +1034,11 @@
             "ms": "2.0.0"
           }
         },
-        "finalhandler": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-          "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
-          }
-        },
-        "fresh": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true
-        },
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
           "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
           "dev": true
-        },
-        "send": {
-          "version": "0.15.6",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
-          "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "fresh": "0.5.2",
-            "http-errors": "1.6.2",
-            "mime": "1.3.4",
-            "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
-          }
-        },
-        "serve-static": {
-          "version": "1.12.6",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
-          "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
-          "dev": true,
-          "requires": {
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
-            "send": "0.15.6"
-          }
         }
       }
     },
@@ -1085,14 +1048,14 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.19",
         "jschardet": "1.5.1",
-        "tmp": "0.0.31"
+        "tmp": "0.0.33"
       }
     },
     "extract-opts": {
@@ -1141,14 +1104,40 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "finalhandler": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "find-up": {
       "version": "1.1.2",
@@ -1161,9 +1150,9 @@
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -1177,10 +1166,26 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
     "forwarded": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.1.tgz",
-      "integrity": "sha1-ik4wxkCwU5U5mjVJxzAldygEiWE=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs.realpath": {
@@ -1241,7 +1246,7 @@
     "get-uri": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.1.tgz",
-      "integrity": "sha1-29ysrNjGCKODFoaTaBF2l6FjHFk=",
+      "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
       "requires": {
         "data-uri-to-buffer": "1.2.0",
         "debug": "2.6.9",
@@ -1275,19 +1280,12 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1354,6 +1352,20 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.2.3",
+        "har-schema": "2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -1379,15 +1391,14 @@
       "dev": true
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
       }
     },
     "he": {
@@ -1397,10 +1408,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -1440,12 +1450,11 @@
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "0.2.0",
+        "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
@@ -1515,16 +1524,16 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
-      "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "2.0.0",
+        "ansi-escapes": "3.0.0",
         "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.4",
+        "external-editor": "2.0.5",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -1749,13 +1758,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "jwa": {
@@ -1983,7 +1985,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -2007,7 +2009,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2067,7 +2069,7 @@
     "mocha-jenkins-reporter": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.3.9.tgz",
-      "integrity": "sha1-ovOr1SrJqqMmzwf2diGE3Zn6ziQ=",
+      "integrity": "sha512-+/nhhGRiAVkoQcapiWdlazL/6/bDr+adQYHQ3sjKR3ipB7O2cZIuGvkgaeKDxMtEFby/ZbWhi2CYHhtJm487GA==",
       "dev": true,
       "requires": {
         "diff": "1.0.7",
@@ -3852,7 +3854,7 @@
     "pac-proxy-agent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.0.tgz",
-      "integrity": "sha1-vrF80rBqILN51X4bLiwpvg3+X5o=",
+      "integrity": "sha512-t57UiJpi5mFLTvjheC1SNSwIhml3+ElNOj69iRrydtQXZJr8VIFYSDtyPi/3ZysA62kD2dmww6pDlzk0VaONZg==",
       "requires": {
         "agent-base": "2.1.1",
         "debug": "2.6.9",
@@ -3861,7 +3863,7 @@
         "https-proxy-agent": "1.0.0",
         "pac-resolver": "3.0.0",
         "raw-body": "2.3.2",
-        "socks-proxy-agent": "3.0.0"
+        "socks-proxy-agent": "3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -3877,7 +3879,7 @@
     "pac-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
+      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
       "requires": {
         "co": "4.6.0",
         "degenerator": "1.0.4",
@@ -3943,6 +3945,11 @@
         "pify": "2.3.0"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3980,9 +3987,9 @@
       "dev": true
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -4021,7 +4028,7 @@
       "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.1",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.4.0"
       }
     },
@@ -4041,6 +4048,11 @@
       "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
       "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U=",
       "dev": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "ramda": {
       "version": "0.24.1",
@@ -4109,7 +4121,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4128,7 +4140,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -4162,123 +4174,6 @@
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "requires": {
-            "ajv": "5.2.3",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        },
-        "sntp": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-          "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
       }
     },
     "require-uncached": {
@@ -4364,7 +4259,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -4385,6 +4280,50 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
       "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+    },
+    "send": {
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
+      "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
+      "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.15.6"
+      }
     },
     "setprototypeof": {
       "version": "1.0.3",
@@ -4467,10 +4406,13 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
     },
     "smart-buffer": {
       "version": "1.1.15",
@@ -4478,12 +4420,11 @@
       "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "socks": {
@@ -4496,9 +4437,9 @@
       }
     },
     "socks-proxy-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
-      "integrity": "sha1-6iMIXNK96U0ISmJEjzETnKftYkU=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
       "requires": {
         "agent-base": "4.1.1",
         "socks": "1.1.10"
@@ -4507,7 +4448,7 @@
         "agent-base": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
-          "integrity": "sha1-ktik/CUko7CbNmajO2yXlg8j1qQ=",
+          "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
           "requires": {
             "es6-promisify": "5.0.0"
           }
@@ -4560,13 +4501,6 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "stack-trace": {
@@ -4642,41 +4576,17 @@
       "dev": true
     },
     "table": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.1.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
       }
     },
     "text-table": {
@@ -4697,9 +4607,9 @@
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -4748,6 +4658,27 @@
         "underscore": "1.8.3"
       },
       "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
         "caseless": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
@@ -4765,6 +4696,15 @@
             "has-ansi": "2.0.0",
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
           }
         },
         "form-data": {
@@ -4788,6 +4728,35 @@
             "commander": "2.9.0",
             "is-my-json-valid": "2.16.1",
             "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "node-uuid": {
@@ -4829,6 +4798,15 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
           }
         },
         "strip-ansi": {
@@ -4936,7 +4914,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -4949,9 +4927,9 @@
       }
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -4962,13 +4940,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "2.4.2",
+  "version": "3.0.0",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {
@@ -24,21 +24,21 @@
   "homepage": "https://github.com/appcelerator/appc-platform-sdk",
   "dependencies": {
     "async": "^2.4.0",
-    "debug": "^2.6.7",
+    "debug": "^3.1.0",
     "getmac": "^1.2.1",
     "pac-proxy-agent": "^2.0.0",
-    "request": "^2.81.0",
-    "tough-cookie": "^2.3.2",
-    "uuid": "^3.0.1"
+    "request": "^2.83.0",
+    "tough-cookie": "^2.3.3",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
-    "body-parser": "^1.17.2",
+    "body-parser": "^1.18.2",
     "clone": "^2.1.1",
-    "cookie-session": "^1.2.0",
+    "cookie-session": "^1.3.2",
     "eslint": "^4.6.1",
     "eslint-config-axway": "^2.0.2",
     "eslint-plugin-mocha": "^4.11.0",
-    "express": "^4.15.3",
+    "express": "^4.15.5",
     "gmail": "0.5.0",
     "mailparser": "^0.5.1",
     "mocha": "^3.5.0",

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -10,6 +10,7 @@ const should = require('should');
 const wrench = require('wrench');
 
 const Appc = require('../');
+require('./lib/helper');
 
 let app;
 let notifier;

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -23,7 +23,11 @@ describe('Appc.Analytics', function () {
 
 	function cleanup() {
 		if (fs.existsSync(Appc.Analytics.dir)) {
-			wrench.rmdirSyncRecursive(Appc.Analytics.dir);
+			try {
+				wrench.rmdirSyncRecursive(Appc.Analytics.dir);
+			} catch (e) {
+				// errors are no big deal
+			}
 		}
 	}
 

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -6,11 +6,8 @@ const fs = require('fs');
 
 const bodyparser = require('body-parser');
 const express = require('express');
-const request = require('request');
 const should = require('should');
 const wrench = require('wrench');
-
-const helper = require('./lib/helper');
 
 const Appc = require('../');
 
@@ -27,7 +24,7 @@ describe('Appc.Analytics', function () {
 		app = express();
 		app.set('port', 4000 + parseInt(1000 * Math.random()));
 		app.use(bodyparser.json());
-		app.post('/track', function (req, resp, next) {
+		app.post('/track', function (req, resp) {
 			resp.json(req.body);
 			notifier && notifier(null, req.body);
 		});
@@ -161,7 +158,7 @@ describe('Appc.Analytics', function () {
 		});
 	});
 
-	it.skip('should send analytics data with no callback', function (done) {
+	it('should send analytics data with no callback', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.flushInterval = 1000;
 		notifier = function (err, result) {
@@ -177,7 +174,7 @@ describe('Appc.Analytics', function () {
 		Appc.Analytics.sendEvent('guid', { data: { a: 1 } });
 	});
 
-	it.skip('should send analytics data immediate', function (done) {
+	it('should send analytics data immediate', function (done) {
 		should(Appc.Analytics).be.an.object;
 		notifier = function (err, result) {
 			should(err).not.be.ok();
@@ -212,7 +209,7 @@ describe('Appc.Analytics', function () {
 		});
 	});
 
-	it.skip('should send analytics after queuing', function (done) {
+	it('should send analytics after queuing', function (done) {
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.flushInterval = 10;
 		notifier = function (err, result) {
@@ -231,10 +228,10 @@ describe('Appc.Analytics', function () {
 		Appc.Analytics.sendEvent('guid', { data: { a: 4 } });
 	});
 
-	it.skip('should send session start and end', function (done) {
+	it('should send session start and end', function (done) {
+		var session;
 		should(Appc.Analytics).be.an.object;
 		Appc.Analytics.flushInterval = 10;
-		var session;
 		notifier = function (err, result) {
 			should(err).not.be.ok();
 			should(result).be.an.array;

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -225,6 +225,7 @@ describe('Appc.Analytics', function () {
 			should(err).not.be.ok();
 			should(result).be.an.Array();
 			should(result).have.length(4);
+			result.sort((a, b) => a - b);
 			should(result[0].data).be.eql({ a: 1 });
 			should(result[1].data).be.eql({ a: 2 });
 			should(result[2].data).be.eql({ a: 3 });
@@ -232,13 +233,10 @@ describe('Appc.Analytics', function () {
 			done();
 		};
 		Appc.Analytics.configure({ interval: 100 });
-		function triggerSend(order) {
-			setTimeout(() => Appc.Analytics.sendEvent('guid', 'event', { data: { a: order } }), order * 5);
-		};
-		triggerSend(1);
-		triggerSend(2);
-		triggerSend(3);
-		triggerSend(4);
+		Appc.Analytics.sendEvent('guid', 'event', { data: { a: 1 } });
+		Appc.Analytics.sendEvent('guid', 'event', { data: { a: 2 } });
+		Appc.Analytics.sendEvent('guid', 'event', { data: { a: 3 } });
+		Appc.Analytics.sendEvent('guid', 'event', { data: { a: 4 } });
 	});
 
 	it('should send session start and end', function (done) {
@@ -249,9 +247,18 @@ describe('Appc.Analytics', function () {
 			should(err).not.be.ok();
 			should(result).be.an.Array();
 			should(result).have.length(3);
-			should(result[0]).have.property('event', 'ti.start');
-			should(result[1]).have.property('event', 'app.feature');
-			should(result[2]).have.property('event', 'ti.end');
+			result.sort(function (a, b) {
+				if (a.event > b.event) {
+					return 1;
+				}
+				if (a.event < b.event) {
+					return -1;
+				}
+				return 0;
+			});
+			should(result[0]).have.property('event', 'app.feature');
+			should(result[1]).have.property('event', 'ti.end');
+			should(result[2]).have.property('event', 'ti.start');
 			should(result[0]).have.property('sid', session.sid);
 			should(result[1]).have.property('sid', session.sid);
 			should(result[2]).have.property('sid', session.sid);
@@ -260,7 +267,7 @@ describe('Appc.Analytics', function () {
 		session = Appc.Analytics.createSession('guid');
 		should(session).be.an.object;
 		should(session.end).be.a.function;
-		setTimeout(() => session.send('app.feature', { a: 1 }), 5);
-		setTimeout(() => session.end(), 10);
+		session.send('app.feature', { a: 1 });
+		session.end();
 	});
 });

--- a/test/app.js
+++ b/test/app.js
@@ -5,7 +5,6 @@ const path = require('path');
 const should = require('should');
 
 const Appc = require('../');
-const helper = require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;
@@ -315,7 +314,7 @@ describe('Appc.App', function () {
 	});
 
 	// skipped due to platform state being incorrectly configured
-	it.skip('should find a free application package by application guid and session', function (done) {
+	it('should find a free application package by application guid and session', function (done) {
 		Appc.App.findPackage(currentSession, global.$config.apps.developer.app_guid, function (err, res) {
 			should.not.exist(err);
 			should.exist(res);
@@ -341,15 +340,6 @@ describe('Appc.App', function () {
 			should.exist(err);
 			err.message.should.equal('Resource Not Found');
 			err.code.should.equal(404);
-			should.not.exist(res);
-			done();
-		});
-	});
-
-	it('should fail to find the team members of an app with an invalid session', function (done) {
-		Appc.App.findTeamMembers({}, global.$config.apps.enterprise.app_id, function (err, res) {
-			should.exist(err);
-			err.message.should.equal('session is not valid');
 			should.not.exist(res);
 			done();
 		});

--- a/test/app.js
+++ b/test/app.js
@@ -5,6 +5,7 @@ const path = require('path');
 const should = require('should');
 
 const Appc = require('../');
+require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const path = require('path');
-
 const should = require('should');
 
 const Appc = require('../');
@@ -55,7 +53,7 @@ describe('Appc.Auth', function () {
 			currentSession.isValid().should.equal(true);
 		});
 
-		it.skip('should be able to request an email auth code with a valid session', function (done) {
+		it('should be able to request an email auth code with a valid session', function (done) {
 			should.exist(currentSession);
 			Appc.Auth.requestLoginCode(currentSession, false, function (err, res) {
 				should.not.exist(err);
@@ -78,7 +76,7 @@ describe('Appc.Auth', function () {
 			});
 		});
 
-		it.skip('should verify the email auth code that was requested earlier', function (done) {
+		it('should verify the email auth code that was requested earlier', function (done) {
 			helper.getAuthCode('email', function (err, res) {
 				should.not.exist(err);
 				should.exist(res);
@@ -92,7 +90,7 @@ describe('Appc.Auth', function () {
 			});
 		});
 
-		it.skip('should be able to request an sms auth code with a valid session', function (done) {
+		it('should be able to request an sms auth code with a valid session', function (done) {
 			should.exist(currentSession);
 
 			Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
@@ -115,7 +113,7 @@ describe('Appc.Auth', function () {
 			});
 		});
 
-		it.skip('should verify the sms auth code that was requested earlier', function (done) {
+		it('should verify the sms auth code that was requested earlier', function (done) {
 			helper.getAuthCode('sms', function (err, res) {
 				should.not.exist(err);
 				should.exist(res);
@@ -129,7 +127,7 @@ describe('Appc.Auth', function () {
 			});
 		});
 
-		it.skip('should get locked out of auth code generation after multiple attempts', function (done) {
+		it('should get locked out of auth code generation after multiple attempts', function (done) {
 			should.exist(currentSession);
 
 			Appc.Auth.requestLoginCode(currentSession, true, function (err, res) {
@@ -155,7 +153,7 @@ describe('Appc.Auth', function () {
 			});
 		});
 
-		it.skip('should be able to request another auth code after valid auth code entry', function (done) {
+		it('should be able to request another auth code after valid auth code entry', function (done) {
 			should.exist(currentSession);
 
 			helper.getAuthCode('sms', function (err, res) {
@@ -174,16 +172,6 @@ describe('Appc.Auth', function () {
 						done();
 					});
 				});
-			});
-		});
-
-		it.skip('should be able to request an email auth code with a valid session', function (done) {
-			should.exist(currentSession);
-
-			Appc.Auth.requestLoginCode(currentSession, false, function (err, res) {
-				should.not.exist(err);
-				should.exist(res);
-				done();
 			});
 		});
 
@@ -215,7 +203,7 @@ describe('Appc.Auth', function () {
 		});
 
 		it('should fail to switch to an invalid org', function (done) {
-			Appc.Auth.switchLoggedInOrg(currentSession, '123', function (err, res, newSession) {
+			Appc.Auth.switchLoggedInOrg(currentSession, '123', function (err, res) {
 				should.exist(err);
 				should.exist(err.message);
 				err.message.should.equal('id is not valid');
@@ -225,7 +213,7 @@ describe('Appc.Auth', function () {
 		});
 
 		it('should fail to switch to an org without a valid session', function (done) {
-			Appc.Auth.switchLoggedInOrg({}, global.$config.user.enterprise_org_id, function (err, res, newSession) {
+			Appc.Auth.switchLoggedInOrg({}, global.$config.user.enterprise_org_id, function (err, res) {
 				should.not.exist(res);
 				should.exist(err);
 				should.exist(err.message);
@@ -235,8 +223,9 @@ describe('Appc.Auth', function () {
 		});
 
 		it('should fail if user tries to log out with an invalid session', function (done) {
+			var invalidSession;
 			should.exist(currentSession);
-			var invalidSession = helper.cloneSession(currentSession);
+			invalidSession = helper.cloneSession(currentSession);
 			invalidSession.invalidate();
 			// try an invalidate again to get more code coverage
 			invalidSession.invalidate();

--- a/test/auth.js
+++ b/test/auth.js
@@ -12,7 +12,7 @@ describe('Appc.Auth', function () {
 
 	describe(global.$config.env + ' environment', function () {
 
-		this.timeout(250000);
+		this.timeout(30000);
 
 		before(function () {
 			Appc.setEnvironment(global.$config.environment);

--- a/test/cloud.js
+++ b/test/cloud.js
@@ -9,6 +9,7 @@ const helper = require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;
+let apiUser;
 
 describe('Appc.Cloud', function () {
 
@@ -230,7 +231,6 @@ describe('Appc.Cloud', function () {
 				});
 		});
 
-		var apiUser;
 		it('should create an Arrow DB user object', function (done) {
 			should.exist(api);
 			should.exist(api.guid);

--- a/test/env.js
+++ b/test/env.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const path = require('path');
-
 const should = require('should');
 
 let Appc = require('../');

--- a/test/env.js
+++ b/test/env.js
@@ -12,8 +12,6 @@ describe('Appc.Env', function () {
 			baseurl: Appc.baseurl,
 			registryurl: Appc.registryurl,
 			pubsuburl: Appc.pubsuburl,
-			webeventurl: Appc.webeventurl,
-			cacheurl: Appc.cacheurl,
 			secureCookies: Appc.secureCookies,
 			supportUntrusted: Appc.supportUntrusted
 		};
@@ -22,13 +20,11 @@ describe('Appc.Env', function () {
 
 	after(function (done) {
 		Appc.setEnvironment(currentEnv);
-		Appc.baseurl.should.equal(currentEnv.baseurl);
-		Appc.registryurl.should.equal(currentEnv.registryurl);
-		Appc.webeventurl.should.equal(currentEnv.webeventurl);
-		Appc.cacheurl.should.equal(currentEnv.cacheurl);
-		Appc.pubsuburl.should.equal(currentEnv.pubsuburl);
-		Appc.secureCookies.should.equal(currentEnv.secureCookies);
-		Appc.supportUntrusted.should.equal(currentEnv.supportUntrusted);
+		should(Appc.baseurl).equal(currentEnv.baseurl);
+		should(Appc.registryurl).equal(currentEnv.registryurl);
+		should(Appc.pubsuburl).equal(currentEnv.pubsuburl);
+		should(Appc.secureCookies).equal(currentEnv.secureCookies);
+		should(Appc.supportUntrusted).equal(currentEnv.supportUntrusted);
 		done();
 	});
 
@@ -44,34 +40,34 @@ describe('Appc.Env', function () {
 				|| !process.env.NODE_ENV
 				&&  !process.env.APPC_ENV
 			) {
-				Appc.isProduction.should.equal(true);
+				should(Appc.isProduction).equal(true);
 			} else {
-				Appc.isProduction.should.equal(false);
+				should(Appc.isProduction).equal(false);
 			}
 		});
 
 		it('should be production', function () {
 			Appc.setProduction();
-			Appc.isProduction.should.equal(true);
+			should(Appc.isProduction).equal(true);
 		});
 
 		it('should not be production when set to development', function () {
 			Appc.setDevelopment();
-			Appc.isProduction.should.equal(false);
+			should(Appc.isProduction).equal(false);
 		});
 
 		it('should not be production when set to local', function () {
 			Appc.setLocal();
-			Appc.isProduction.should.equal(false);
+			should(Appc.isProduction).equal(false);
 		});
 
 		it('should be able to be changed', function () {
 			Appc.setDevelopment();
-			Appc.isProduction.should.equal(false);
+			should(Appc.isProduction).equal(false);
 			Appc.setProduction();
-			Appc.isProduction.should.equal(true);
+			should(Appc.isProduction).equal(true);
 			Appc.setLocal();
-			Appc.isProduction.should.equal(false);
+			should(Appc.isProduction).equal(false);
 		});
 	});
 
@@ -83,20 +79,16 @@ describe('Appc.Env', function () {
 				isProduction: false,
 				supportUntrusted: true,
 				registry: 'http://registry.com',
-				webevent: 'http://webevent.com',
-				cache: 'http://cache.com',
 				pubsub: 'http://pubsub.com'
 			};
 
 			Appc.setEnvironment(customEnv);
 
-			Appc.isProduction.should.equal(false);
-			Appc.supportUntrusted.should.equal(true);
-			Appc.baseurl.should.equal('http://test.appcelerator.com:8080/Appc');
-			Appc.registryurl.should.equal('http://registry.com');
-			Appc.webeventurl.should.equal('http://webevent.com');
-			Appc.cacheurl.should.equal('http://cache.com');
-			Appc.pubsuburl.should.equal('http://pubsub.com');
+			should(Appc.isProduction).equal(false);
+			should(Appc.supportUntrusted).equal(true);
+			should(Appc.baseurl).equal('http://test.appcelerator.com:8080/Appc');
+			should(Appc.registryurl).equal('http://registry.com');
+			should(Appc.pubsuburl).equal('http://pubsub.com');
 		});
 	});
 
@@ -106,21 +98,17 @@ describe('Appc.Env', function () {
 			process.env.APPC_DASHBOARD_URL = 'http://360-env.appcelerator.com';
 			process.env.APPC_REGISTRY_SERVER = 'http://software-env.appcelerator.com';
 			process.env.APPC_PUBSUB_URL = 'http://pubsub-env.appcelerator.com';
-			process.env.APPC_WEBEVENT_URL = 'http://webevent-env.appcelerator.com';
-			process.env.APPC_CACHE_URL = 'http://webevent-env.appcelerator.com';
 			process.env.APPC_SUPPORT_UNTRUSTED = 'false';
 			process.env.APPC_SECURE_COOKIES = 'false';
 
 			delete require.cache[require.resolve('../lib/env')];
 			let Env = require('../lib/env');
 
-			Env.secureCookies.should.equal(false);
-			Env.supportUntrusted.should.equal(false);
-			Env.baseurl.should.equal('http://360-env.appcelerator.com');
-			Env.registryurl.should.equal('http://software-env.appcelerator.com');
-			Env.pubsuburl.should.equal('http://pubsub-env.appcelerator.com');
-			Env.webeventurl.should.equal('http://webevent-env.appcelerator.com');
-			Env.cacheurl.should.equal('http://webevent-env.appcelerator.com');
+			should(Env.secureCookies).equal(false);
+			should(Env.supportUntrusted).equal(false);
+			should(Env.baseurl).equal('http://360-env.appcelerator.com');
+			should(Env.registryurl).equal('http://software-env.appcelerator.com');
+			should(Env.pubsuburl).equal('http://pubsub-env.appcelerator.com');
 		});
 	});
 });

--- a/test/event.js
+++ b/test/event.js
@@ -3,7 +3,6 @@
 const should = require('should');
 
 const Appc = require('../');
-const helper = require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;

--- a/test/event.js
+++ b/test/event.js
@@ -3,6 +3,7 @@
 const should = require('should');
 
 const Appc = require('../');
+require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;

--- a/test/feed.js
+++ b/test/feed.js
@@ -3,6 +3,7 @@
 const should = require('should');
 
 const Appc = require('../');
+require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;

--- a/test/feed.js
+++ b/test/feed.js
@@ -3,7 +3,6 @@
 const should = require('should');
 
 const Appc = require('../');
-const helper = require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;
@@ -46,7 +45,7 @@ describe('Appc.Feed', function () {
 		});
 	});
 
-	it('should find all the feeds for the logged in user', function (done) {
+	it('should find all the feeds with limit', function (done) {
 		Appc.Feed.findAll(currentSession, { limit: 2 }, function (err, res) {
 			should.exist(res);
 			should.not.exist(err);

--- a/test/lib/helper.js
+++ b/test/lib/helper.js
@@ -1,12 +1,11 @@
 'use strict';
 
+require('../conf/loader').load();
+
 const clone = require('clone');
 const gm = require('gmail');
 const MailParser = require('mailparser').MailParser;
-const should = require('should');
 const twilio = require('twilio');
-
-const ConfigLoader = require('../conf/loader').load();
 
 const Appc = require('../..');
 
@@ -35,7 +34,7 @@ exports.objectContainsObject = objectContainsObject;
 function getCloudEnvironment(session, type, name, callback) {
 	try {
 		return callback(null, Appc.Cloud.getEnvironment(session, type, name));
-	} catch(err) {
+	} catch (err) {
 		return callback(err);
 	}
 }

--- a/test/notification.js
+++ b/test/notification.js
@@ -3,7 +3,6 @@
 const should = require('should');
 
 const Appc = require('../');
-const helper = require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;

--- a/test/notification.js
+++ b/test/notification.js
@@ -3,6 +3,7 @@
 const should = require('should');
 
 const Appc = require('../');
+require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;

--- a/test/org.js
+++ b/test/org.js
@@ -8,6 +8,8 @@ const helper = require('./lib/helper');
 let currentSession;
 let orgName;
 let user = global.$config.user;
+let regularTime;
+let cachedTime;
 
 describe('Appc.Org', function () {
 
@@ -149,9 +151,6 @@ describe('Appc.Org', function () {
 			done();
 		});
 	});
-
-	var regularTime,
-		cachedTime;
 
 	it('should find the orgs that the user has access to', function (done) {
 		var time = new Date().getTime();

--- a/test/user.js
+++ b/test/user.js
@@ -3,7 +3,6 @@
 const should = require('should');
 
 const Appc = require('../');
-const helper = require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;

--- a/test/user.js
+++ b/test/user.js
@@ -3,6 +3,7 @@
 const should = require('should');
 
 const Appc = require('../');
+require('./lib/helper');
 
 let currentSession;
 let user = global.$config.user;


### PR DESCRIPTION
## Version 3.0.0

### Deprecation Notice

This version removes availability of `Env.webeventurl` and `Env.cacheurl` as those services will be sunset.

### Adoption Warning

The changes to `Env.registryurl` and `Env.pubsuburl` precede those services' availability on the updated domains.  Please do not adopt this version if you've not replaced references to those services or provided overrides for their current domains.