### PR TITLE
[APPTS-9537] Fix up test cases and add new analytics configuration

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -22,12 +22,12 @@ const Appc = require('.');
 /**
  * default location of the analytics cache
  */
-const ANALYTICS_DIR = path.join(os.homedir && os.homedir() || process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE || '/tmp', '.appc-analytics');
+let ANALYTICS_DIR = path.join(os.homedir && os.homedir() || process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE || '/tmp', '.appc-analytics');
 
 /**
  * URL for sending data
  */
-const url = Appc.analyticsurl;
+let ANALYTICS_URL = Appc.analyticsurl;
 
 /**
  * The interval in ms to send analytics.
@@ -35,20 +35,44 @@ const url = Appc.analyticsurl;
  * This should not be set to a lower number, as we're using
  * an interval which does not wait for flush completion.
  */
-const flushInterval = 10000;
+let FLUSH_INTERVAL = 10000;
 
 // exports definitions, other stuff is private
 let Analytics = exports = module.exports = {
-	ANALYTICS_DIR: ANALYTICS_DIR,
+	configure,
 	createSession,
+	flush: flushEvents,
 	sendEvent,
-	flush,
-	stopFlush,
-	url
+	startFlush,
+	stopFlush
 };
+
+// define read only props to avoid modification
+Object.defineProperties(module.exports, {
+	dir: { get: () => ANALYTICS_DIR },
+	url: { get: () => ANALYTICS_URL },
+	flushInterval: { get: () => FLUSH_INTERVAL }
+});
 
 // global timeout ref
 let timeout;
+
+/**
+ * Configuration hook to allow modifying state.
+ *
+ * @param {*} opts
+ * 		the options to override internally.
+ */
+function configure(opts = {}) {
+	ANALYTICS_DIR = opts.dir || ANALYTICS_DIR;
+	ANALYTICS_URL = opts.url || ANALYTICS_URL;
+
+	if (opts.interval) {
+		FLUSH_INTERVAL = opts.interval;
+		stopFlush();
+		startFlush();
+	}
+}
 
 /**
  * Creates a new analytics session and triggers the
@@ -140,19 +164,23 @@ function sendEvent(app_guid, event_name, props, callback, immediate) {
 	props.platform && (event.platform = props.platform);
 
 	// store the event on disk
-	storeEvent(event);
+	storeEvent(event, function (err) {
+		if (err) {
+			return finished(err);
+		}
 
-	// immediately send if needed (if immediate was originally
-	// set to true, or a callback was provided).
-	if (immediate) {
-		return flushEvents(finished);
-	}
+		// immediately send if needed (if immediate was originally
+		// set to true, or a callback was provided).
+		if (immediate) {
+			return flushEvents(finished);
+		}
 
-	// start sending events (if not already running)
-	flush();
+		// start sending events (if not already running)
+		startFlush();
 
-	// pass back payload, false means not immediately sent
-	finished(null, [ event ], false);
+		// pass back payload, false means not immediately sent
+		finished(null, [ event ], false);
+	});
 }
 
 /**
@@ -161,9 +189,9 @@ function sendEvent(app_guid, event_name, props, callback, immediate) {
  * This is a timeout rather than an interval to control
  * the async behaviour of the triggered flush.
  */
-function flush() {
-	debug('flush');
-	!timeout && (timeout = setTimeout(flushEvents, flushInterval));
+function startFlush() {
+	debug('startFlush');
+	!timeout && (timeout = setTimeout(flushEvents, FLUSH_INTERVAL));
 }
 
 /**
@@ -201,7 +229,7 @@ function storeEvent(payload, callback) {
 
 			// create the missing directory structure
 			return fs.mkdir(ANALYTICS_DIR, function (err) {
-				if (err) {
+				if (err && err.code !== 'EEXIST') {
 					return callback(err);
 				}
 				// add the payload
@@ -247,14 +275,19 @@ function appendPayload(payload, callback) {
  * @private
  */
 function flushEvents(callback) {
+	// create a default callback for debugging
+	callback = callback || function defaultCallback(err) {
+		err && debug('flushEvents failure', err);
+	};
+
 	// attach a hook to log errors if missing callback
 	function finished(err, data, sent, cancel) {
-		!cancel && flush();
+		!cancel && startFlush();
 		if (callback) {
 			return callback(err, data, sent);
 		}
 		err && debug('flushEvents failure', err);
-	};
+	}
 
 	// read all files in the analytics directory
 	fs.readdir(ANALYTICS_DIR, function (err, files) {
@@ -274,12 +307,16 @@ function flushEvents(callback) {
 			return callback(null, [], false, true);
 		}
 
+		// map files to ensure full path
+		files = files.map(function (file) {
+			return path.join(ANALYTICS_DIR, file);
+		});
+
 		async.map(
 			files,
 			function (file, next) {
 				// read in each file and parse it as JSON
-				let joinedPath = path.join(ANALYTICS_DIR, file);
-				fs.readFile(joinedPath, function (err, contents) {
+				fs.readFile(file, function (err, contents) {
 					if (err) {
 						return next(err);
 					}
@@ -293,7 +330,7 @@ function flushEvents(callback) {
 
 				// req opts
 				let opts = {
-					url: url,
+					url: ANALYTICS_URL,
 					method: 'POST',
 					json: data,
 					timeout: 30000
@@ -319,7 +356,7 @@ function flushEvents(callback) {
 					debug('flushEvents cleanup');
 					async.each(files, fs.unlink, function (err) {
 						err && debug('flushEvents cleanup error', err);
-						return err ? callback(err) : callback(null, opts.data, true);
+						return err ? callback(err) : callback(null, opts.json , true);
 					});
 				});
 			}

--- a/lib/env.js
+++ b/lib/env.js
@@ -61,8 +61,7 @@ let Env = exports = module.exports = {};
 Env.props = Object.keys(envs.Production);
 
 // Set analytics URL.
-const analyticsUrl = 'https://api.appcelerator.net/p/v2/partner-track';
-Env.analyticsurl = analyticsUrl;
+Env.analyticsurl = 'https://api.appcelerator.net/p/v2/partner-track';
 
 /**
  * Map default envs to setter functions.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {
-    "test": "APPC_ENV=development nyc -r text-summary --temp-directory ./coverage --clean mocha -R spec -t 40000 --check-leaks",
+    "test": "APPC_ENV=development nyc -r text-summary --temp-directory ./coverage --clean mocha -R spec -t 40000",
     "lint": "eslint --ext .js ./",
     "ci-lint": "eslint --ext .js ./ || exit 0"
   },

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -235,7 +235,7 @@ describe('Appc.Analytics', function () {
 		};
 		Appc.Analytics.configure({ interval: 100 });
 		function triggerSend(order) {
-			setTimeout(() => Appc.Analytics.sendEvent('guid', 'event', { data: { a: order } }), order);
+			setTimeout(() => Appc.Analytics.sendEvent('guid', 'event', { data: { a: order } }), order * 5);
 		};
 		triggerSend(1);
 		triggerSend(2);
@@ -262,7 +262,7 @@ describe('Appc.Analytics', function () {
 		session = Appc.Analytics.createSession('guid');
 		should(session).be.an.object;
 		should(session.end).be.a.function;
-		setTimeout(() => session.send('app.feature', { a: 1 }), 1);
-		setTimeout(() => session.end(), 2);
+		setTimeout(() => session.send('app.feature', { a: 1 }), 5);
+		setTimeout(() => session.end(), 10);
 	});
 });

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -23,35 +23,43 @@ describe('Appc.Analytics', function () {
 
 	this.timeout(30000);
 
+	function cleanup() {
+		if (fs.existsSync(Appc.Analytics.dir)) {
+			wrench.rmdirSyncRecursive(Appc.Analytics.dir);
+		}
+	}
+
+	function proxy() {
+		Appc.Analytics.configure({ url: 'http://127.0.0.1:' + app.get('port') + '/track' });
+	}
+
 	before(function (done) {
 		app = express();
 		app.set('port', 4000 + parseInt(1000 * Math.random()));
 		app.use(bodyparser.json());
-		app.post('/track', function (req, resp, next) {
-			resp.json(req.body);
-			notifier && notifier(null, req.body);
+		app.post('/track', function (req, resp) {
+			resp.status(204).end();
+			notifier && setImmediate(notifier.bind(notifier, null, req.body));
 		});
 		app.listen(app.get('port'), function () {
 			originalUrl = Appc.Analytics.url;
 			originalInterval = Appc.Analytics.flushInterval;
-			Appc.Analytics.url = 'http://127.0.0.1:' + app.get('port') + '/track';
+			proxy();
 			done();
 		});
-		fs.existsSync(Appc.Analytics.analyticsDir) && wrench.rmdirSyncRecursive(Appc.Analytics.analyticsDir);
 	});
 
-	after(function (done) {
-		Appc.Analytics.url = originalUrl;
-		Appc.Analytics.flushInterval = originalInterval;
-		fs.existsSync(Appc.Analytics.analyticsDir) && wrench.rmdirSyncRecursive(Appc.Analytics.analyticsDir);
-		done();
+	after(function () {
+		Appc.Analytics.configure({
+			url: originalUrl,
+			interval: originalInterval
+		});
 	});
 
+	beforeEach(cleanup);
 	afterEach(function () {
-		Appc.Analytics.stopFlush();
-		Appc.Analytics.url = 'http://127.0.0.1:' + app.get('port') + '/track';
-		notifier = null;
-		fs.existsSync(Appc.Analytics.analyticsDir) && wrench.rmdirSyncRecursive(Appc.Analytics.analyticsDir);
+		proxy();
+		cleanup();
 	});
 
 	it('should send analytics data with guid and event only', function (done) {
@@ -161,9 +169,9 @@ describe('Appc.Analytics', function () {
 		});
 	});
 
-	it.skip('should send analytics data with no callback', function (done) {
+	it('should send analytics data with no callback', function (done) {
 		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.flushInterval = 1000;
+		Appc.Analytics.configure({ interval: 1000 });
 		notifier = function (err, result) {
 			should(err).not.be.ok();
 			should(result).be.an.array;
@@ -174,28 +182,29 @@ describe('Appc.Analytics', function () {
 			should(result[0].data).be.eql({ a: 1 });
 			done();
 		};
-		Appc.Analytics.sendEvent('guid', { data: { a: 1 } });
+		Appc.Analytics.sendEvent('guid', 'event', { data: { a: 1 } });
 	});
 
-	it.skip('should send analytics data immediate', function (done) {
+	it('should send analytics data immediate', function (done) {
 		should(Appc.Analytics).be.an.object;
-		notifier = function (err, result) {
+		notifier = null;
+		Appc.Analytics.sendEvent('guid', 'event', {}, function (err, result, sent) {
 			should(err).not.be.ok();
-			should(result).be.an.array;
+			should(result).be.an.Array();
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
 			should(result[0]).have.property('aguid', 'guid');
+			should(sent).equal(true);
 			done();
-		};
-		Appc.Analytics.sendEvent('guid', null, null, true);
+		}, true);
 	});
 
 	it('should send analytics to real url and get back result', function (done) {
 		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.url = originalUrl;
+		Appc.Analytics.configure({ url: originalUrl });
 		Appc.Analytics.sendEvent(global.$config.apps.enterprise.app_guid, 'app.feature', {}, function (err, result, sent) {
 			should(err).not.be.ok();
-			should(result).be.an.array;
+			should(result).be.an.Array();
 			should(result).have.length(1);
 			should(result[0]).have.property('id');
 			should(result[0]).have.property('mid');
@@ -212,12 +221,11 @@ describe('Appc.Analytics', function () {
 		});
 	});
 
-	it.skip('should send analytics after queuing', function (done) {
-		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.flushInterval = 10;
+	it('should send analytics after queuing', function (done) {
+		should(Appc.Analytics).be.an.Object();
 		notifier = function (err, result) {
 			should(err).not.be.ok();
-			should(result).be.an.array;
+			should(result).be.an.Array();
 			should(result).have.length(4);
 			should(result[0].data).be.eql({ a: 1 });
 			should(result[1].data).be.eql({ a: 2 });
@@ -225,19 +233,23 @@ describe('Appc.Analytics', function () {
 			should(result[3].data).be.eql({ a: 4 });
 			done();
 		};
-		Appc.Analytics.sendEvent('guid', { data: { a: 1 } });
-		Appc.Analytics.sendEvent('guid', { data: { a: 2 } });
-		Appc.Analytics.sendEvent('guid', { data: { a: 3 } });
-		Appc.Analytics.sendEvent('guid', { data: { a: 4 } });
+		Appc.Analytics.configure({ interval: 100 });
+		function triggerSend(order) {
+			setTimeout(() => Appc.Analytics.sendEvent('guid', 'event', { data: { a: order } }), order);
+		};
+		triggerSend(1);
+		triggerSend(2);
+		triggerSend(3);
+		triggerSend(4);
 	});
 
-	it.skip('should send session start and end', function (done) {
-		should(Appc.Analytics).be.an.object;
-		Appc.Analytics.flushInterval = 10;
+	it('should send session start and end', function (done) {
+		should(Appc.Analytics).be.an.Object();
+		Appc.Analytics.configure({ interval: 100 });
 		var session;
 		notifier = function (err, result) {
 			should(err).not.be.ok();
-			should(result).be.an.array;
+			should(result).be.an.Array();
 			should(result).have.length(3);
 			should(result[0]).have.property('event', 'ti.start');
 			should(result[1]).have.property('event', 'app.feature');
@@ -250,8 +262,7 @@ describe('Appc.Analytics', function () {
 		session = Appc.Analytics.createSession('guid');
 		should(session).be.an.object;
 		should(session.end).be.a.function;
-		session.send({ a: 1 });
-		session.end();
+		setTimeout(() => session.send('app.feature', { a: 1 }), 1);
+		setTimeout(() => session.end(), 2);
 	});
-
 });


### PR DESCRIPTION
This PR will fix up the analytics tests (what a nightmare that was). It also adds a new `configure()` function to the analytics lib to allow you to change stuff, rather than overwriting properties. I had to remove `--check-leaks` from the test command because it basically just breaks stuff (i.e. if a leak happens in a `before`, that entire suite will fail).

Most of the failing stuff appears to have been broken for months. There are a bunch of tests verifying order, but due to how events are stored on disk order isn't guaranteed; bunch of annoyance like that. 