### PR TITLE
3.0.2 - [APPTS-10080] Force (re)inheritance of env vars when setting default environment

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -52,6 +52,7 @@ Object.keys(envs).forEach(function (env) {
 	Env['set' + env] = function () {
 		Object.assign(Env, envs[env]);
 		debug('set env to', env, ', baseurl is', Env.baseurl);
+		_inheritEnvVars();
 	};
 });
 
@@ -76,15 +77,13 @@ Env.setLocal = function setLocal() {
  */
 Env.setEnvironment = function setEnvironment(opts) {
 	opts = opts || {};
-	let baseEnvKey = _getEnvKey();
-	let base = envs[baseEnvKey] || envs.Production;
-	Env.baseurl = (opts.baseurl || base.baseurl).trim();
-	Env.registryurl = (opts.registry || base.registryurl).trim();
-	Env.pubsuburl = (opts.pubsub || base.pubsuburl).trim();
-	Env.isProduction = typeof opts.isProduction !== 'undefined' ? opts.isProduction : base.isProduction;
-	Env.supportUntrusted = typeof opts.supportUntrusted !== 'undefined' ? opts.supportUntrusted : base.supportUntrusted;
-	Env.secureCookies = typeof opts.secureCookies !== 'undefined' ? opts.secureCookies : base.secureCookies;
-	debug('set custom environment ' + JSON.stringify(opts) + ' to ' + Env.baseurl);
+	opts.baseurl && (Env.baseurl = opts.baseurl.trim());
+	opts.registryurl && (Env.registryurl = opts.registryurl.trim());
+	opts.pubsuburl && (Env.pubsuburl = opts.pubsuburl.trim());
+	typeof opts.isProduction !== 'undefined' && (Env.isProduction = opts.isProduction);
+	typeof opts.supportUntrusted !== 'undefined' && (Env.supportUntrusted = opts.supportUntrusted);
+	typeof opts.secureCookies !== 'undefined' && (Env.secureCookies = opts.secureCookies);
+	debug('set custom environment to ' + JSON.stringify(opts));
 };
 
 /**
@@ -129,9 +128,11 @@ function _getEnvKey() {
 
 /**
  * Check process.env vars for override values.
+
+ * @param {*} [ctx] an Env-like object 
  * @return {void}
  */
-function _inheritEnvVars() {
+function _inheritEnvVars(ctx) {
 	Object.keys(platformMap).forEach(function (prop) {
 		let name = platformMap[prop];
 		let val = process.env[name];
@@ -143,7 +144,7 @@ function _inheritEnvVars() {
 			val === 'false' && (val = false);
 
 			// Override prop if env var differs.
-			Env[prop] !== val && (Env[prop] = val);
+			(ctx || Env)[prop] !== val && ((ctx || Env)[prop] = val);
 		}
 	});
 }
@@ -151,6 +152,3 @@ function _inheritEnvVars() {
 // Set default env based on NODE_ENV/APPC_ENV.
 let defaultEnv = _getEnvKey();
 Env['set' + defaultEnv]();
-
-// Override props with env vars.
-_inheritEnvVars();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Appcelerator Platform SDK for node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://github.com/appcelerator/appc-platform-sdk",
   "dependencies": {
-    "async": "^2.4.0",
+    "async": "^2.6.1",
     "debug": "^3.1.0",
-    "getmac": "^1.2.1",
+    "getmac": "^1.4.3",
     "pac-proxy-agent": "^2.0.0",
-    "request": "^2.83.0",
-    "tough-cookie": "^2.3.3",
-    "uuid": "^3.1.0"
+    "request": "^2.87.0",
+    "tough-cookie": "^2.4.2",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "body-parser": "^1.18.2",
@@ -46,7 +46,7 @@
     "nyc": "^11.2.1",
     "prompt": "^1.0.0",
     "should": "^11.2.1",
-    "twilio": "^2.11.1",
+    "twilio": "^3.17.2",
     "wrench": "^1.5.8"
   }
 }

--- a/test/env.js
+++ b/test/env.js
@@ -145,7 +145,7 @@ describe('Appc.Env', function () {
 			should(Env.registryurl).equal('http://software-env.appcelerator.com');
 			should(Env.pubsuburl).equal('http://pubsub-env.appcelerator.com');
 			should(Env.secureCookies).equal(false);
-			should(Env.supportUntrusted).equal(false);
+			should(Env.supportUntrusted).equal(true);
 
 			// should allow custom overrides
 			Env.setEnvironment({ baseurl: 'http://custom.baseurl.com' });
@@ -154,7 +154,7 @@ describe('Appc.Env', function () {
 			should(Env.registryurl).equal('http://software-env.appcelerator.com');
 			should(Env.pubsuburl).equal('http://pubsub-env.appcelerator.com');
 			should(Env.secureCookies).equal(false);
-			should(Env.supportUntrusted).equal(false);
+			should(Env.supportUntrusted).equal(true);
 		});
 	});
 });

--- a/test/env.js
+++ b/test/env.js
@@ -2,19 +2,43 @@
 
 const should = require('should');
 
-let Appc = require('../');
-let currentEnv = {};
+const Appc = require('../');
+
+const currentEnv = {};
+const envs = {
+	Production: {
+		baseurl: 'https://platform.axway.com',
+		registryurl: 'https://registry.platform.axway.com',
+		pubsuburl: 'https://pubsub.platform.axway.com',
+		isProduction: true,
+		supportUntrusted: false,
+		secureCookies: true
+	},
+	Preproduction: {
+		baseurl: 'https://platform-preprod.axwaytest.net',
+		registryurl: 'https://registry.axwaytest.net',
+		pubsuburl: 'https://pubsub.axwaytest.net',
+		isProduction: false,
+		supportUntrusted: true,
+		secureCookies: true
+	},
+	ProductionEU: {
+		baseurl: 'https://platform-eu.appcelerator.com',
+		registryurl: 'https://software-eu.appcelerator.com',
+		pubsuburl: 'https://pubsub.appcelerator.com',
+		isProduction: true,
+		supportUntrusted: false,
+		secureCookies: true
+	}
+};
 
 describe('Appc.Env', function () {
 
 	before(function (done) {
-		currentEnv = {
-			baseurl: Appc.baseurl,
-			registryurl: Appc.registryurl,
-			pubsuburl: Appc.pubsuburl,
-			secureCookies: Appc.secureCookies,
-			supportUntrusted: Appc.supportUntrusted
-		};
+		Object.assign(currentEnv, Appc.props.reduce(function (curr, prop) {
+			curr[prop] = Appc[prop];
+			return curr;
+		}, {}));
 		done();
 	});
 
@@ -25,40 +49,42 @@ describe('Appc.Env', function () {
 		should(Appc.pubsuburl).equal(currentEnv.pubsuburl);
 		should(Appc.secureCookies).equal(currentEnv.secureCookies);
 		should(Appc.supportUntrusted).equal(currentEnv.supportUntrusted);
+		should(Appc.isProduction).equal(currentEnv.isProduction);
 		done();
 	});
 
 	describe('default environments', function () {
 
-		it('should default env from NODE_ENV or APPC_ENV', function () {
-			if (process.env.NODE_ENV === 'production'
-				|| process.env.APPC_ENV === 'production'
-				|| process.env.NODE_ENV === 'production-eu'
-				|| process.env.APPC_ENV === 'production-eu'
-				|| process.env.NODE_ENV === 'platform-axway'
-				|| process.env.APPC_ENV === 'platform-axway'
-				|| !process.env.NODE_ENV
-				&&  !process.env.APPC_ENV
-			) {
-				should(Appc.isProduction).equal(true);
-			} else {
-				should(Appc.isProduction).equal(false);
-			}
+		it('should set default env from NODE_ENV or APPC_ENV', function () {
+			const isProduction = String(process.env.NODE_ENV).startsWith('production')
+				|| String(process.env.APPC_ENV).startsWith('production')
+				|| (!process.env.NODE_ENV && !process.env.APPC_ENV);
+			should(Appc.isProduction).equal(isProduction);
 		});
 
 		it('should be production', function () {
 			Appc.setProduction();
-			should(Appc.isProduction).equal(true);
+			should(Appc.baseurl).equal(envs.Production.baseurl);
+			should(Appc.isProduction).equal(envs.Production.isProduction);
+		});
+
+		it('should not be production when set to preproduction', function () {
+			Appc.setPreproduction();
+			should(Appc.baseurl).equal(envs.Preproduction.baseurl);
+			should(Appc.isProduction).equal(false);
 		});
 
 		it('should not be production when set to development', function () {
 			Appc.setDevelopment();
+			should(Appc.baseurl).equal(envs.Preproduction.baseurl);
 			should(Appc.isProduction).equal(false);
 		});
 
 		it('should not be production when set to local', function () {
 			Appc.setLocal();
+			should(Appc.baseurl).equal('http://localhost:9009');
 			should(Appc.isProduction).equal(false);
+			should(Appc.secureCookies).equal(false);
 		});
 
 		it('should be able to be changed', function () {
@@ -76,39 +102,59 @@ describe('Appc.Env', function () {
 		it('should allow a custom environment', function () {
 			let customEnv = {
 				baseurl: 'http://test.appcelerator.com:8080/Appc',
+				registryurl: 'http://registry.com',
+				pubsuburl: 'http://pubsub.com',
 				isProduction: false,
-				supportUntrusted: true,
-				registry: 'http://registry.com',
-				pubsub: 'http://pubsub.com'
+				secureCookies: false,
+				supportUntrusted: true
 			};
 
 			Appc.setEnvironment(customEnv);
 
-			should(Appc.isProduction).equal(false);
-			should(Appc.supportUntrusted).equal(true);
-			should(Appc.baseurl).equal('http://test.appcelerator.com:8080/Appc');
-			should(Appc.registryurl).equal('http://registry.com');
-			should(Appc.pubsuburl).equal('http://pubsub.com');
+			should(Appc.baseurl).equal(customEnv.baseurl);
+			should(Appc.registryurl).equal(customEnv.registryurl);
+			should(Appc.pubsuburl).equal(customEnv.pubsuburl);
+			should(Appc.isProduction).equal(customEnv.isProduction);
+			should(Appc.secureCookies).equal(customEnv.secureCookies);
+			should(Appc.supportUntrusted).equal(customEnv.supportUntrusted);
 		});
 	});
 
 	describe('overrides from process.env', function () {
 
-		it('should use override with ENV variables', function () {
+		it('should use env variables', function () {
 			process.env.APPC_DASHBOARD_URL = 'http://360-env.appcelerator.com';
 			process.env.APPC_REGISTRY_SERVER = 'http://software-env.appcelerator.com';
 			process.env.APPC_PUBSUB_URL = 'http://pubsub-env.appcelerator.com';
-			process.env.APPC_SUPPORT_UNTRUSTED = 'false';
+			process.env.APPC_SUPPORT_UNTRUSTED = 'true';
 			process.env.APPC_SECURE_COOKIES = 'false';
 
 			delete require.cache[require.resolve('../lib/env')];
 			let Env = require('../lib/env');
 
-			should(Env.secureCookies).equal(false);
-			should(Env.supportUntrusted).equal(false);
 			should(Env.baseurl).equal('http://360-env.appcelerator.com');
 			should(Env.registryurl).equal('http://software-env.appcelerator.com');
 			should(Env.pubsuburl).equal('http://pubsub-env.appcelerator.com');
+			should(Env.secureCookies).equal(false);
+			should(Env.supportUntrusted).equal(true);
+
+			// should not override when setting default envs
+			Env.setProduction();
+
+			should(Env.baseurl).equal('http://360-env.appcelerator.com');
+			should(Env.registryurl).equal('http://software-env.appcelerator.com');
+			should(Env.pubsuburl).equal('http://pubsub-env.appcelerator.com');
+			should(Env.secureCookies).equal(false);
+			should(Env.supportUntrusted).equal(false);
+
+			// should allow custom overrides
+			Env.setEnvironment({ baseurl: 'http://custom.baseurl.com' });
+
+			should(Env.baseurl).equal('http://custom.baseurl.com');
+			should(Env.registryurl).equal('http://software-env.appcelerator.com');
+			should(Env.pubsuburl).equal('http://pubsub-env.appcelerator.com');
+			should(Env.secureCookies).equal(false);
+			should(Env.supportUntrusted).equal(false);
 		});
 	});
 });


### PR DESCRIPTION
https://techweb.axway.com/jira/browse/APPTS-10080

Addresses a case where appc-cli's multiple calls to Appc.setProduction() was causing props read from env vars to be overridden. Env prop priority going forward is as follows (in order of "stickiness"):

- overrides set via Appc.setEnvironment
- env vars read from process.env
- environments set via Appc.set{env}
- default environment

Env test suite covers the case, but the fix is demonstrated in practice with the following. 

```
$ APPC_SECURE_COOKIES=false node
> process.env.APPC_SECURE_COOKIES // 'false'
> const a = require('.')
> a.secureCookies // false
> a.setProduction()
> a.secureCookies // false
> a.setPreproduction()
> a.baseurl // 'https://platform-preprod.axwaytest.net'
> a.secureCookies // false
> a.setEnvironment({ secureCookies: true });
> a.secureCookies // true
```
