### PR TITLE
3.2.0 - [APPTS-11034] Adoption of Platform API 7.0.0 changes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -24,7 +24,6 @@ let App = exports = module.exports = {
 	find,
 	findAll,
 	findPackage,
-	findTeamMembers,
 	save,
 	update,
 	updateTiApp: save
@@ -161,13 +160,6 @@ function findPackage(session, guid, token, callback) {
 		callback = token;
 	}
 	Appc.createRequest(session || token, '/api/v1/app/' + guid + '/package', callback);
-}
-
-/**
- * for a given application guid, find the configuration application teams
- */
-function findTeamMembers(session, guid, callback) {
-	Appc.createRequest(session, '/api/v1/app/' + guid + '/team', callback);
 }
 
 /**

--- a/lib/cloud.js
+++ b/lib/cloud.js
@@ -235,7 +235,7 @@ function createApp(session, appName, orgId, appGuid, callback) {
  * @param {Function} callback callback to hit on completion
  */
 function createUser(session, group_id, env, keyvalues, callback) {
-	let req = Appc.createRequest(session, '/api/v1/acs/' + group_id + '/' + env + '/data.next/user', 'post', createACSResponseHandler('users', callback));
+	let req = Appc.createRequest(session, '/api/v1/acs/' + group_id + '/' + env + '/data/user', 'post', createACSResponseHandler('users', callback));
 	if (req) {
 		let form = req.form();
 		Object.keys(keyvalues).forEach(function (key) {
@@ -278,5 +278,5 @@ function getEnvironment(session, type, name) {
  * @param {Function} callback callback to hit on completion
  */
 function retrieveUsers(session, group_id, env, callback) {
-	Appc.createRequest(session, '/api/v1/acs/' + group_id + '/' + env + '/data.next/user', createACSResponseHandler('users', callback));
+	Appc.createRequest(session, '/api/v1/acs/' + group_id + '/' + env + '/data/user', createACSResponseHandler('users', callback));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-platform-sdk",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Appcelerator Platform SDK for Node.JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR...

- Removes the unused App.findTeamMembers function since app team functionality is replaced with org-level teams in Platform API/Dashboard 7.0.0
- Re-paths the Cloud.createUser/retrieveUser API calls (the API will continue to work on the deprecated `data.next` path)
